### PR TITLE
refactor: code-health quick wins (#17, #18)

### DIFF
--- a/src/lib/generators/DashboardGenerator.ts
+++ b/src/lib/generators/DashboardGenerator.ts
@@ -124,7 +124,7 @@ export class DashboardGenerator {
         `;
 
         // --- Layout Diagram (Simple Grid Table) ---
-        const buildMermaidLayout = () => {
+        const buildLayoutGrid = () => {
             if (layoutItems.length === 0) {
                 return '';
             }
@@ -465,7 +465,7 @@ export class DashboardGenerator {
                 <!-- Layout Diagram -->
                 <div>
                     <h3 class="text-lg font-bold text-slate-800 mb-4">📐 Layout</h3>
-                    ${buildMermaidLayout()}
+                    ${buildLayoutGrid()}
                 </div>
 
                 ${dashboardParamsHtml}

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -593,7 +593,6 @@ export class EtlParser {
                     src = this.getTextSafe(storage.DataSource?.Description || 'Datasource');
                 if (stepType === 'RunDirectQuery') src = `Query: ${table}`;
                 fl = `${src} ➔ ${target}`;
-                fl = `${src} ➔ ${target}`;
             } else if (stepType === 'ImportWarehouseData') {
                 fl = `Save to Warehouse: ${target}`;
             } else if (stepType === 'PurgeTable') {


### PR DESCRIPTION
Two trivial code-health fixes from the PR #16 review backlog.

## Changes
- **#17** — Rename `buildMermaidLayout` → `buildLayoutGrid` in `DashboardGenerator.ts`. The function renders an HTML grid table, not a Mermaid diagram; the old name was misleading. Updated the single call site.
- **#18** — Remove redundant duplicate `fl` assignment in `EtlParser.ts` (accidental copy-paste).

## Verification
- `tsc --noEmit` clean
- 56/56 tests pass
- `vite build` succeeds (pre-commit hook)

Closes #17
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)