### PR TITLE
Type raw-XML consumers + flip XmlNode index sig to XmlValue (#28)

### DIFF
--- a/src/lib/FileProcessor.ts
+++ b/src/lib/FileProcessor.ts
@@ -4,12 +4,26 @@ import { db } from './db';
 
 import { DataModelParser } from './parsers/DataModelParser';
 import { DashboardParser } from './parsers/DashboardParser';
-import { asNode, type XmlNode } from './parsers/types';
+import { asNode, type XmlNode, type XmlValue } from './parsers/types';
 
 const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
 });
+
+/**
+ * Coerce a leaf XmlValue to a string. With `ignoreAttributes: false`, attributed
+ * nodes parse as `{ '@_x': ..., '#text': ... }`; extract `#text` so metadata
+ * isn't stored as "[object Object]". '' for other objects/arrays/nullish.
+ */
+function getText(val: XmlValue): string {
+    if (val == null) return '';
+    if (typeof val === 'object') {
+        const node = asNode(val);
+        return node && typeof node['#text'] === 'string' ? node['#text'] : '';
+    }
+    return String(val);
+}
 
 /**
  * Recursively parse any string field that looks like XML.
@@ -142,12 +156,12 @@ export class FileProcessor {
 
         // Extract ProcessMode deeply
         const rootDef = asNode(asNode(dmDef.Definition)?.DataModelDefinition) || dmDef;
-        const processMode = rootDef.ProcessMode || 'N/A';
+        const processMode = getText(rootDef.ProcessMode) || 'N/A';
 
         // Name Strategy:
         // 1. Description from XML (usually the cleanest name)
         // 2. Fallback to Filename, with GUID/Timestamp stripped
-        let cleanName = typeof dmDef.Description === 'string' ? dmDef.Description : '';
+        let cleanName = getText(dmDef.Description);
         if (!cleanName) {
             cleanName = file.name.replace(/\.t1dm$/i, '');
             // Remove GUID if present (e.g. _c2dfa917-7450-42b8-a5bb-f5802916cedc...)
@@ -159,11 +173,11 @@ export class FileProcessor {
 
         const metadata = {
             name: cleanName,
-            id: String(dmDef.DataModelId || 'N/A'),
-            description: String(dmDef.Description || 'Imported Data Model'),
-            version: String(dmDef.Version || '1.0'),
-            owner: String(dmDef.Owner || 'Unknown'),
-            processMode: String(processMode),
+            id: getText(dmDef.DataModelId) || 'N/A',
+            description: getText(dmDef.Description) || 'Imported Data Model',
+            version: getText(dmDef.Version) || '1.0',
+            owner: getText(dmDef.Owner) || 'Unknown',
+            processMode: processMode,
             dateModified: new Date().toISOString(),
         };
 
@@ -185,17 +199,14 @@ export class FileProcessor {
         const dashDef = asNode(asNode(content.Dashboard)?.EntityDef) || {};
 
         // Name: Use Description as the primary name
-        const name =
-            typeof dashDef.Description === 'string' && dashDef.Description
-                ? dashDef.Description
-                : file.name.replace(/\.t1db$/i, '');
+        const name = getText(dashDef.Description) || file.name.replace(/\.t1db$/i, '');
 
         const metadata = {
             name: name,
-            id: String(dashDef.GenericEntityId || 'N/A'),
-            description: String(dashDef.Description || ''),
-            owner: String(dashDef.Owner || 'Unknown'),
-            parentPath: String(dashDef.ParentFileItemPath || ''),
+            id: getText(dashDef.GenericEntityId) || 'N/A',
+            description: getText(dashDef.Description),
+            owner: getText(dashDef.Owner) || 'Unknown',
+            parentPath: getText(dashDef.ParentFileItemPath),
             dateModified: new Date().toISOString(),
         };
 

--- a/src/lib/FileProcessor.ts
+++ b/src/lib/FileProcessor.ts
@@ -4,35 +4,38 @@ import { db } from './db';
 
 import { DataModelParser } from './parsers/DataModelParser';
 import { DashboardParser } from './parsers/DashboardParser';
+import { asNode, type XmlNode } from './parsers/types';
 
 const parser = new XMLParser({
     ignoreAttributes: false,
-    attributeNamePrefix: "@_"
+    attributeNamePrefix: '@_',
 });
 
 /**
  * Recursively parse any string field that looks like XML.
  * This ensures ALL nested XML content is fully extracted.
  */
-function deepParseAllXml(obj: any): void {
+function deepParseAllXml(obj: XmlNode): void {
     if (!obj || typeof obj !== 'object') return;
 
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         const val = obj[key];
-        if (typeof val === 'string' && val.trim().startsWith('<?xml') || 
-            (typeof val === 'string' && val.trim().startsWith('<') && val.trim().endsWith('>'))) {
+        if (
+            (typeof val === 'string' && val.trim().startsWith('<?xml')) ||
+            (typeof val === 'string' && val.trim().startsWith('<') && val.trim().endsWith('>'))
+        ) {
             try {
-                const parsed = parser.parse(val);
+                const parsed = parser.parse(val as string) as XmlNode;
                 obj[key] = parsed;
                 // Recursively parse the newly parsed object
-                deepParseAllXml(obj[key]);
+                deepParseAllXml(parsed);
             } catch (_e) {
                 // Not valid XML, leave as string
             }
         } else if (Array.isArray(val)) {
-            val.forEach(item => deepParseAllXml(item));
-        } else if (typeof val === 'object') {
-            deepParseAllXml(val);
+            val.forEach((item) => deepParseAllXml(item as XmlNode));
+        } else if (val && typeof val === 'object') {
+            deepParseAllXml(val as XmlNode);
         }
     });
 }
@@ -51,17 +54,11 @@ export class FileProcessor {
 
         // 1. Unzip
         const zip = await JSZip.loadAsync(file);
-        
+
         // 2. Parse ALL XML files in the archive
         const rawData: Record<string, any> = {};
-        
-        const xmlFiles = [
-            'Processes.xml',
-            'Steps.xml',
-            'Variables.xml',
-            'FileLocations.xml',
-            'Attachments.xml'
-        ];
+
+        const xmlFiles = ['Processes.xml', 'Steps.xml', 'Variables.xml', 'FileLocations.xml', 'Attachments.xml'];
 
         for (const fileName of xmlFiles) {
             const f = zip.file(fileName);
@@ -85,18 +82,21 @@ export class FileProcessor {
         // 3. Extract Basic Metadata
         const procXml = rawData.Processes;
         const rawProcs = procXml?.ArrayOfProcess?.Process || procXml?.Process?.ArrayOfProcess?.Process;
-        const procList = Array.isArray(rawProcs) ? rawProcs : (rawProcs ? [rawProcs] : []);
+        const procList = Array.isArray(rawProcs) ? rawProcs : rawProcs ? [rawProcs] : [];
 
-        const getUnique = (arr: any[], key: string) => [...new Set(arr.map(x => x[key]).filter(Boolean))].join(', ');
+        const getUnique = (arr: any[], key: string) => [...new Set(arr.map((x) => x[key]).filter(Boolean))].join(', ');
 
         const rawOwner = getUnique(procList, 'Owner') || 'N/A';
         let publisher = rawOwner;
-        let publishedDate = getUnique(procList, 'DateSaved') || getUnique(procList, 'DateModified') || new Date().toISOString();
+        let publishedDate =
+            getUnique(procList, 'DateSaved') || getUnique(procList, 'DateModified') || new Date().toISOString();
         const narration = getUnique(procList, 'VersionNarration') || getUnique(procList, 'Narration') || '';
 
         // Try to extract actual publisher and date from narration (e.g. "Published by MGUPTA on 28-Nov-2025 17:55:48")
         if (narration && narration.includes('Published by ')) {
-            const match = narration.match(/Published by\s+([A-Za-z0-9_]+)(?:\s+on\s+([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}\s+[0-9:]{8}))?/i);
+            const match = narration.match(
+                /Published by\s+([A-Za-z0-9_]+)(?:\s+on\s+([0-9]{1,2}-[A-Za-z]{3}-[0-9]{4}\s+[0-9:]{8}))?/i
+            );
             if (match) {
                 if (match[1]) publisher = match[1];
                 if (match[2]) publishedDate = match[2];
@@ -114,7 +114,7 @@ export class FileProcessor {
             dateModified: publishedDate,
             // HIGH VALUE fields
             processType: getUnique(procList, 'ProcessType') || '$ETL',
-            parentPath: getUnique(procList, 'ParentFileItemPath') || ''
+            parentPath: getUnique(procList, 'ParentFileItemPath') || '',
         };
 
         // 4. Save to DB - now includes all parsed XML files
@@ -126,7 +126,7 @@ export class FileProcessor {
             rawVariables: rawData.Variables || {},
             rawFileLocations: rawData.FileLocations || {},
             rawAttachments: rawData.Attachments || {},
-            dateAdded: new Date()
+            dateAdded: new Date(),
         });
 
         console.log(`Saved report ${reportId} to DB`);
@@ -137,37 +137,41 @@ export class FileProcessor {
         const content = await DataModelParser.parse(file);
 
         // Extract basic metadata safely
-        const dmDef = content.DataModel?.DataModelDef || content.DataModel?.DataModelDefinition || {};
+        const dataModel = asNode(content.DataModel);
+        const dmDef = asNode(dataModel?.DataModelDef) || asNode(dataModel?.DataModelDefinition) || {};
 
         // Extract ProcessMode deeply
-        const rootDef = dmDef.Definition?.DataModelDefinition || dmDef;
+        const rootDef = asNode(asNode(dmDef.Definition)?.DataModelDefinition) || dmDef;
         const processMode = rootDef.ProcessMode || 'N/A';
 
         // Name Strategy:
         // 1. Description from XML (usually the cleanest name)
         // 2. Fallback to Filename, with GUID/Timestamp stripped
-        let cleanName = dmDef.Description;
+        let cleanName = typeof dmDef.Description === 'string' ? dmDef.Description : '';
         if (!cleanName) {
             cleanName = file.name.replace(/\.t1dm$/i, '');
             // Remove GUID if present (e.g. _c2dfa917-7450-42b8-a5bb-f5802916cedc...)
-            cleanName = cleanName.replace(/_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}.*$/, '');
+            cleanName = cleanName.replace(
+                /_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}.*$/,
+                ''
+            );
         }
 
         const metadata = {
             name: cleanName,
-            id: dmDef.DataModelId || 'N/A',
-            description: dmDef.Description || 'Imported Data Model',
-            version: dmDef.Version || '1.0',
-            owner: dmDef.Owner || 'Unknown',
-            processMode: processMode,
-            dateModified: new Date().toISOString()
+            id: String(dmDef.DataModelId || 'N/A'),
+            description: String(dmDef.Description || 'Imported Data Model'),
+            version: String(dmDef.Version || '1.0'),
+            owner: String(dmDef.Owner || 'Unknown'),
+            processMode: String(processMode),
+            dateModified: new Date().toISOString(),
         };
 
         const id = await db.dataModels.add({
             filename: file.name,
             metadata,
             content, // Parsed JSON of all XMLs
-            dateAdded: new Date()
+            dateAdded: new Date(),
         });
 
         console.log(`Saved Data Model ${id} to DB`);
@@ -178,25 +182,28 @@ export class FileProcessor {
         const content = await DashboardParser.parse(file);
 
         // Extract metadata from Dashboard.xml
-        const dashDef = content.Dashboard?.EntityDef || {};
+        const dashDef = asNode(asNode(content.Dashboard)?.EntityDef) || {};
 
         // Name: Use Description as the primary name
-        const name = dashDef.Description || file.name.replace(/\.t1db$/i, '');
+        const name =
+            typeof dashDef.Description === 'string' && dashDef.Description
+                ? dashDef.Description
+                : file.name.replace(/\.t1db$/i, '');
 
         const metadata = {
             name: name,
-            id: dashDef.GenericEntityId || 'N/A',
-            description: dashDef.Description || '',
-            owner: dashDef.Owner || 'Unknown',
-            parentPath: dashDef.ParentFileItemPath || '',
-            dateModified: new Date().toISOString()
+            id: String(dashDef.GenericEntityId || 'N/A'),
+            description: String(dashDef.Description || ''),
+            owner: String(dashDef.Owner || 'Unknown'),
+            parentPath: String(dashDef.ParentFileItemPath || ''),
+            dateModified: new Date().toISOString(),
         };
 
         const id = await db.dashboards.add({
             filename: file.name,
             metadata,
             content, // Parsed JSON of all XMLs
-            dateAdded: new Date()
+            dateAdded: new Date(),
         });
 
         console.log(`Saved Dashboard ${id} to DB`);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from 'dexie';
+import type { DataModelParsed, DashboardParsed } from './parsers/types';
 
 export interface Report {
     id?: number;
@@ -13,14 +14,14 @@ export interface Report {
         narration?: string;
         dateModified?: string;
         // HIGH VALUE - shown in both views
-        processType?: string;        // e.g., "$ETL", "$SCRIPT"
-        parentPath?: string;         // T1 file hierarchy path
+        processType?: string; // e.g., "$ETL", "$SCRIPT"
+        parentPath?: string; // T1 file hierarchy path
     };
     rawProcess: any;
     rawSteps: any;
-    rawVariables?: any;       // Variables.xml - process parameters
-    rawFileLocations?: any;   // FileLocations.xml - file path references
-    rawAttachments?: any;     // Attachments.xml - embedded files
+    rawVariables?: any; // Variables.xml - process parameters
+    rawFileLocations?: any; // FileLocations.xml - file path references
+    rawAttachments?: any; // Attachments.xml - embedded files
     dateAdded: Date;
     stepNotes?: Record<string, string>; // Map of stepId -> note text
 }
@@ -36,7 +37,7 @@ export interface DataModel {
         owner?: string;
         dateModified?: string;
     };
-    content: any; // Holds the parsed DataModel, Queries, etc.
+    content: DataModelParsed; // Holds the parsed DataModel, Queries, etc.
     dateAdded: Date;
     stepNotes?: Record<string, string>; // Map of QueryName/Id -> note text
 }
@@ -52,7 +53,7 @@ export interface Dashboard {
         parentPath?: string;
         dateModified?: string;
     };
-    content: any; // Holds parsed JSON from all XMLs
+    content: DashboardParsed; // Holds parsed JSON from all XMLs
     dateAdded: Date;
     stepNotes?: Record<string, string>; // Map of widgetId -> note text
 }
@@ -65,15 +66,15 @@ export class T1AnalyserDB extends Dexie {
     constructor() {
         super('T1AnalyserDB');
         this.version(1).stores({
-            reports: '++id, filename, dateAdded' // Primary key and indexed props
+            reports: '++id, filename, dateAdded', // Primary key and indexed props
         });
         // Version 2: Add dataModels
         this.version(2).stores({
-            dataModels: '++id, filename, dateAdded'
+            dataModels: '++id, filename, dateAdded',
         });
         // Version 3: Add dashboards
         this.version(3).stores({
-            dashboards: '++id, filename, dateAdded'
+            dashboards: '++id, filename, dateAdded',
         });
     }
 }

--- a/src/lib/generators/DashboardGenerator.ts
+++ b/src/lib/generators/DashboardGenerator.ts
@@ -17,7 +17,10 @@ export class DashboardGenerator {
 
         const getText = (val: XmlValue): string => {
             if (val == null) return '';
-            if (typeof val === 'object') return '';
+            if (typeof val === 'object') {
+                const node = asNode(val);
+                return node && typeof node['#text'] === 'string' ? node['#text'] : '';
+            }
             return String(val);
         };
 
@@ -37,7 +40,7 @@ export class DashboardGenerator {
         };
 
         const escapeHtml = (str: XmlValue): string => {
-            if (!str) return '';
+            if (str == null) return '';
             return String(str)
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')

--- a/src/lib/generators/DashboardGenerator.ts
+++ b/src/lib/generators/DashboardGenerator.ts
@@ -1,4 +1,5 @@
 import { db } from '../db';
+import { asNode, type XmlNode, type XmlValue } from '../parsers/types';
 
 export class DashboardGenerator {
     static async generateHtmlView(id: number, mode: 'business' | 'technical' = 'business'): Promise<string> {
@@ -9,9 +10,15 @@ export class DashboardGenerator {
         const metadata = dashboard.metadata;
 
         // --- Helpers ---
-        const getList = (obj: any): any[] => {
-            if (!obj) return [];
-            return Array.isArray(obj) ? obj : [obj];
+        const getList = (obj: XmlValue): XmlNode[] => {
+            if (obj == null) return [];
+            return (Array.isArray(obj) ? obj : [obj]) as XmlNode[];
+        };
+
+        const getText = (val: XmlValue): string => {
+            if (val == null) return '';
+            if (typeof val === 'object') return '';
+            return String(val);
         };
 
         const formatDate = (dateStr: string) => {
@@ -29,7 +36,7 @@ export class DashboardGenerator {
             }
         };
 
-        const escapeHtml = (str: string): string => {
+        const escapeHtml = (str: XmlValue): string => {
             if (!str) return '';
             return String(str)
                 .replace(/&/g, '&amp;')
@@ -39,7 +46,7 @@ export class DashboardGenerator {
                 .replace(/'/g, '&#039;');
         };
 
-        const renderTable = (headers: string[], rows: any[]) => {
+        const renderTable = (headers: string[], rows: Record<string, string>[]) => {
             if (!rows || rows.length === 0) return '';
             const ths = headers
                 .map(
@@ -62,13 +69,13 @@ export class DashboardGenerator {
         };
 
         // --- Extract Data ---
-        const dashDef = content.Dashboard?.EntityDef || {};
-        const dashLayout = dashDef.Definition?.Dashboard || {};
-        const layoutItems = getList(dashLayout.Layout?.LayoutItem || []);
-        const visualizations = getList(content.Visualisations?.ArrayOfEntityDef?.EntityDef || []);
-        const variables = getList(content.Variables?.ArrayOfVariableDef?.VariableDef || []);
+        const dashDef = asNode(asNode(content.Dashboard)?.EntityDef) || {};
+        const dashLayout = asNode(asNode(dashDef.Definition)?.Dashboard) || {};
+        const layoutItems = getList(asNode(dashLayout.Layout)?.LayoutItem);
+        const visualizations = getList(asNode(content.Visualisations?.ArrayOfEntityDef)?.EntityDef);
+        const variables = getList(asNode(content.Variables?.ArrayOfVariableDef)?.VariableDef);
 
-        const widgetMap = new Map(visualizations.map((v: any) => [v.GenericEntityId, v]));
+        const widgetMap = new Map(visualizations.map((v) => [getText(v.GenericEntityId), v]));
         const displayDate = formatDate(metadata.dateModified || dashboard.dateAdded.toISOString());
 
         // --- Metadata Grid ---
@@ -80,11 +87,11 @@ export class DashboardGenerator {
                 </div>
                 <div>
                     <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Folder</span>
-                    <span class="font-medium text-gray-800 text-xs truncate" title="${metadata.parentPath || dashDef.ParentFileItemPath || ''}">${(metadata.parentPath || dashDef.ParentFileItemPath || '-').split('/').pop()}</span>
+                    <span class="font-medium text-gray-800 text-xs truncate" title="${metadata.parentPath || getText(dashDef.ParentFileItemPath) || ''}">${(metadata.parentPath || getText(dashDef.ParentFileItemPath) || '-').split('/').pop()}</span>
                 </div>
                 <div class="text-right">
                     <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">System ID</span>
-                    <span class="font-mono text-gray-600 text-xs">${(dashDef.GenericEntityId || '-').substring(0, 12)}...</span>
+                    <span class="font-mono text-gray-600 text-xs">${(getText(dashDef.GenericEntityId) || '-').substring(0, 12)}...</span>
                 </div>
                 <div>
                     <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Reporting System</span>
@@ -96,15 +103,15 @@ export class DashboardGenerator {
                 </div>
                 <div class="text-right">
                     <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Dashboard ID</span>
-                    <span class="font-mono text-gray-500 text-[11px] truncate inline-block" title="${dashDef.GenericEntityId}">${(dashDef.GenericEntityId || 'N/A').substring(0, 12)}</span>
+                    <span class="font-mono text-gray-500 text-[11px] truncate inline-block" title="${getText(dashDef.GenericEntityId)}">${(getText(dashDef.GenericEntityId) || 'N/A').substring(0, 12)}</span>
                 </div>
             </div>
         `;
 
         // --- Executive Summary ---
         const widgetTypes = new Map<string, number>();
-        visualizations.forEach((v: any) => {
-            const type = v.EntitySubType || 'UNKNOWN';
+        visualizations.forEach((v) => {
+            const type = getText(v.EntitySubType) || 'UNKNOWN';
             widgetTypes.set(type, (widgetTypes.get(type) || 0) + 1);
         });
 
@@ -118,7 +125,7 @@ export class DashboardGenerator {
                     <span class="text-lg">📋</span> Executive Summary
                 </h3>
                 <p class="text-slate-700 text-lg leading-relaxed">
-                    This dashboard contains <strong>${visualizations.length} widgets</strong> (${typeBreakdown}) across <strong>${new Set(visualizations.map((v: any) => v.AttributeString1)).size} data models</strong> to provide business intelligence and reporting capabilities.
+                    This dashboard contains <strong>${visualizations.length} widgets</strong> (${typeBreakdown}) across <strong>${new Set(visualizations.map((v) => getText(v.AttributeString1))).size} data models</strong> to provide business intelligence and reporting capabilities.
                 </p>
             </div>
         `;
@@ -133,20 +140,20 @@ export class DashboardGenerator {
             let maxRow = 0;
             const widgetsByPos = new Map<string, { name: string; type: string; width: number }>();
 
-            layoutItems.forEach((item: any) => {
-                const widget = widgetMap.get(item.Id);
-                const x = item.X || 0;
+            layoutItems.forEach((item) => {
+                const widget = widgetMap.get(getText(item.Id));
+                const x = Number(item.X) || 0;
                 // Guard the 12-column grid: x >= 12 would make width <= 0, and a
                 // zero/negative colspan never advances `col` in the render loop
                 // below -> infinite loop. Skip out-of-range items, clamp width >= 1.
                 if (x >= 12) return;
-                const row = Math.floor((item.Y || 0) / 100);
-                const width = Math.max(1, Math.min(item.Width || 1, 12 - x));
+                const row = Math.floor((Number(item.Y) || 0) / 100);
+                const width = Math.max(1, Math.min(Number(item.Width) || 1, 12 - x));
 
                 maxRow = Math.max(maxRow, row);
                 widgetsByPos.set(`${row},${x}`, {
-                    name: widget?.Description || 'Widget',
-                    type: widget?.EntitySubType || 'UNKNOWN',
+                    name: getText(widget?.Description) || 'Widget',
+                    type: getText(widget?.EntitySubType) || 'UNKNOWN',
                     width: width,
                 });
             });
@@ -189,10 +196,10 @@ export class DashboardGenerator {
 
         // --- Dashboard-level Parameters Section ---
         let dashboardParamsHtml = '';
-        const dashParams = dashLayout.Parameters?.ParameterField || [];
+        const dashParams = asNode(dashLayout.Parameters)?.ParameterField;
         const dashParamsList = getList(dashParams);
         if (dashParamsList.length > 0 && mode === 'technical') {
-            const paramRows = dashParamsList.map((p: any) => ({
+            const paramRows = dashParamsList.map((p) => ({
                 Col1: escapeHtml(p.FieldName || 'N/A'),
                 Col2: `<code class="bg-gray-100 px-2 py-1 rounded text-xs font-mono">${escapeHtml(p.Value || 'N/A')}</code>`,
                 Col3: escapeHtml(p.Description || '-'),
@@ -216,14 +223,14 @@ export class DashboardGenerator {
         // --- Widget Summary Table ---
         let widgetSummaryHtml = '';
         if (visualizations.length > 0) {
-            const widgetRows = visualizations.map((v: any, idx: number) => {
+            const widgetRows = visualizations.map((v, idx: number) => {
                 const criteriaCount = this.countCriteria(v.AttributeText1);
                 const paramCount = this.countParams(v.AttributeText2);
                 return {
                     Col1: `${idx + 1}`,
-                    Col2: v.Description || 'Unnamed',
-                    Col3: v.EntitySubType || 'UNKNOWN',
-                    Col4: v.DatamodelDescription || '-',
+                    Col2: getText(v.Description) || 'Unnamed',
+                    Col3: getText(v.EntitySubType) || 'UNKNOWN',
+                    Col4: getText(v.DatamodelDescription) || '-',
                     Col5:
                         criteriaCount > 0
                             ? `<span class="bg-orange-100 text-orange-800 px-2 py-1 rounded text-xs">${criteriaCount}</span>`
@@ -256,21 +263,23 @@ export class DashboardGenerator {
             detailedWidgetsHtml =
                 '<details class="group mb-6"><summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-purple-50 hover:bg-purple-100 transition-colors select-none border-t border-b border-purple-200"><span class="text-xl font-bold text-slate-800 flex items-center gap-3"><span class="text-purple-500 text-lg">📋</span> Widget Details</span></summary><div class="pt-4 pb-2 px-2 space-y-4">';
 
-            visualizations.forEach((widget: any) => {
-                const criteria = widget.AttributeText1?.CriteriaSetItem?.CriteriaValues?.CriteriaValue || [];
+            visualizations.forEach((widget) => {
+                const criteria = asNode(
+                    asNode(asNode(widget.AttributeText1)?.CriteriaSetItem)?.CriteriaValues
+                )?.CriteriaValue;
                 const criteriaList = getList(criteria);
-                const params = widget.AttributeText2?.Parameters?.ParameterField || [];
+                const params = asNode(asNode(widget.AttributeText2)?.Parameters)?.ParameterField;
                 const paramsList = getList(params);
-                const tableDef = widget.Definition?.Table;
+                const tableDef = asNode(asNode(widget.Definition)?.Table);
                 const columns = tableDef?.Columns ? getList(tableDef.Columns) : [];
                 let filterHtml = '';
                 let paramHtml = '';
                 let columnHtml = '';
 
                 if (criteriaList.length > 0) {
-                    const filterRows = criteriaList.map((c: any) => ({
+                    const filterRows = criteriaList.map((c) => ({
                         Col1: escapeHtml(c.ColumnId || 'N/A'),
-                        Col2: escapeHtml(c.Operator?.Value || '='),
+                        Col2: escapeHtml(asNode(c.Operator)?.Value || '='),
                         Col3: `<code class="bg-gray-100 px-2 py-1 rounded text-xs font-mono">${escapeHtml(c.Value1 || 'N/A')}</code>`,
                         Col4: escapeHtml(c.Link || 'AND'),
                     }));
@@ -283,7 +292,7 @@ export class DashboardGenerator {
                 }
 
                 if (paramsList.length > 0) {
-                    const paramRows = paramsList.map((p: any) => ({
+                    const paramRows = paramsList.map((p) => ({
                         Col1: escapeHtml(p.FieldName || 'N/A'),
                         Col2: `<code class="bg-gray-100 px-2 py-1 rounded text-xs font-mono">${escapeHtml(p.Value || 'N/A')}</code>`,
                     }));
@@ -296,7 +305,7 @@ export class DashboardGenerator {
                 }
 
                 if (columns.length > 0) {
-                    const columnRows = columns.map((col: any) => {
+                    const columnRows = columns.map((col) => {
                         let formula = '';
                         let isCalculation = false;
                         if (col.Expression) {
@@ -369,7 +378,7 @@ export class DashboardGenerator {
                             </div>
                             <div>
                                 <div class="text-xs font-semibold text-gray-600">Widget ID</div>
-                                <div class="font-mono text-xs text-gray-700 break-all">${escapeHtml((widget.GenericEntityId || 'N/A').substring(0, 16))}...</div>
+                                <div class="font-mono text-xs text-gray-700 break-all">${escapeHtml((getText(widget.GenericEntityId) || 'N/A').substring(0, 16))}...</div>
                             </div>
                         </div>
                         ${filterHtml}
@@ -394,12 +403,12 @@ export class DashboardGenerator {
                 F: 'Float',
             };
 
-            const varRows = variables.map((v: any) => ({
-                Col1: v.Name || '-',
-                Col2: typeMap[v.VariableType || ''] || v.VariableType || '-',
-                Col3: v.DefaultValue || '-',
-                Col4: v.SelectionTypeListType || v.ListType || '-',
-                Col5: v.Description || '-',
+            const varRows = variables.map((v) => ({
+                Col1: getText(v.Name) || '-',
+                Col2: typeMap[getText(v.VariableType)] || getText(v.VariableType) || '-',
+                Col3: getText(v.DefaultValue) || '-',
+                Col4: getText(v.SelectionTypeListType || v.ListType) || '-',
+                Col5: getText(v.Description) || '-',
             }));
 
             variablesHtml = `
@@ -419,13 +428,14 @@ export class DashboardGenerator {
         }
 
         // --- Data Model Dependencies ---
-        const dmIds = new Set(visualizations.map((v: any) => v.AttributeString1).filter(Boolean));
+        const dmIds = new Set(visualizations.map((v) => getText(v.AttributeString1)).filter(Boolean));
         let dependenciesHtml = '';
         if (dmIds.size > 0) {
-            const dmRows = Array.from(dmIds).map((id: any) => {
+            const dmRows = Array.from(dmIds).map((id) => {
                 const dmName =
-                    visualizations.find((v: any) => v.AttributeString1 === id)?.DatamodelDescription || 'Unknown';
-                const widgetCount = visualizations.filter((v: any) => v.AttributeString1 === id).length;
+                    getText(visualizations.find((v) => getText(v.AttributeString1) === id)?.DatamodelDescription) ||
+                    'Unknown';
+                const widgetCount = visualizations.filter((v) => getText(v.AttributeString1) === id).length;
                 return {
                     Col1: dmName,
                     Col2: `${widgetCount} widget${widgetCount !== 1 ? 's' : ''}`,
@@ -477,18 +487,16 @@ export class DashboardGenerator {
         `;
     }
 
-    private static countCriteria(criteriaText: any): number {
-        if (!criteriaText) return 0;
-        const criteria = criteriaText.CriteriaSetItem;
+    private static countCriteria(criteriaText: XmlValue): number {
+        const criteria = asNode(asNode(criteriaText)?.CriteriaSetItem);
         if (!criteria) return 0;
-        const values = criteria.CriteriaValues?.CriteriaValue;
+        const values = asNode(criteria.CriteriaValues)?.CriteriaValue;
         if (!values) return 0;
         return Array.isArray(values) ? values.length : 1;
     }
 
-    private static countParams(paramsText: any): number {
-        if (!paramsText) return 0;
-        const params = paramsText.Parameters?.ParameterField;
+    private static countParams(paramsText: XmlValue): number {
+        const params = asNode(asNode(paramsText)?.Parameters)?.ParameterField;
         if (!params) return 0;
         return Array.isArray(params) ? params.length : 1;
     }

--- a/src/lib/generators/DataModelGenerator.ts
+++ b/src/lib/generators/DataModelGenerator.ts
@@ -1,18 +1,18 @@
 import { db } from '../db';
 import { ExpressionFormatter } from '../formatters/ExpressionFormatter';
+import { asNode, type DataModelParsed, type XmlNode, type XmlValue } from '../parsers/types';
 
 export class DataModelGenerator {
     static async generateHtmlView(id: number, _viewMode: 'business' | 'technical' = 'business'): Promise<string> {
         const dm = await db.dataModels.get(id);
-        if (!dm) throw new Error("Data Model not found");
+        if (!dm) throw new Error('Data Model not found');
 
         const content = dm.content;
         const metadata = dm.metadata;
 
         // Extract ProcessMode
-        const rootDef = content.DataModel?.DataModelDef || content.DataModel?.Definition;
+        const rootDef = asNode(content.DataModel?.DataModelDef) || asNode(content.DataModel?.Definition);
         const processMode = rootDef?.ProcessMode || 'N/A';
-
 
         // --- Section: Header ---
         const formatDate = (dateStr: string) => {
@@ -56,115 +56,138 @@ export class DataModelGenerator {
 
         // Variables
         // Variables
-        const rawVars = this.getList(content.Variables?.ArrayOfVariableDef?.VariableDef);
+        const rawVars = this.getList(asNode(content.Variables?.ArrayOfVariableDef)?.VariableDef);
         const resolveType = (t: string) => {
             const types: Record<string, string> = {
-                'A': 'String',
-                'L': 'Boolean',
-                'N': 'Numeric',
-                'D': 'Date',
-                'I': 'Integer',
-                'F': 'Float'
+                A: 'String',
+                L: 'Boolean',
+                N: 'Numeric',
+                D: 'Date',
+                I: 'Integer',
+                F: 'Float',
             };
             return types[t] || t || 'String';
         };
 
-        const variables = rawVars.map((v: any) => ({
-            Name: v.Name,
-            Value: v.DefaultValue,
-            Type: resolveType(v.DataType || v.VariableType),
-            Source: v.DataSourceName || '',
-            Description: v.Description
+        const variables = rawVars.map((v) => ({
+            Name: this.getText(v.Name),
+            Value: this.getText(v.DefaultValue),
+            Type: resolveType(this.getText(v.DataType || v.VariableType)),
+            Source: this.getText(v.DataSourceName),
+            Description: this.getText(v.Description),
         }));
-        const variableSet = new Set(variables.map((v: any) => v.Name));
+        const variableSet = new Set(variables.map((v) => v.Name));
 
         // Indexes
-        const rawIndexes = this.getList(content.DataModel?.Definition?.DataModelDefinition?.Indexes?.Index);
-        const indexes = rawIndexes.map((idx: any) => ({
-            Name: idx.Name,
-            Columns: this.getList(idx.Columns?.Column).map((c: any) => c.Name).join(', ')
+        const dmDefinition = asNode(asNode(content.DataModel?.Definition)?.DataModelDefinition);
+        const rawIndexes = this.getList(asNode(dmDefinition?.Indexes)?.Index);
+        const indexes = rawIndexes.map((idx) => ({
+            Name: this.getText(idx.Name),
+            Columns: this.getList(asNode(idx.Columns)?.Column)
+                .map((c) => this.getText(c.Name))
+                .join(', '),
         }));
-        const indexMap = new Map(indexes.map((i: any) => [i.Name, i]));
+        const indexMap = new Map(indexes.map((i) => [i.Name, i]));
 
         // Drilldown Views (Detail Views)
-        const rawViews = this.getList(content.DataModel?.Definition?.DataModelDefinition?.DetailViews?.View);
-        const views = rawViews.map((v: any) => ({
-            Name: v.Name,
-            Columns: this.getList(v.Columns?.Column).map((c: any) => c.Name).join(', ')
+        const rawViews = this.getList(asNode(dmDefinition?.DetailViews)?.View);
+        const views = rawViews.map((v) => ({
+            Name: this.getText(v.Name),
+            Columns: this.getList(asNode(v.Columns)?.Column)
+                .map((c) => this.getText(c.Name))
+                .join(', '),
         }));
 
         // Queries - Sort by Sequence
-        const rawQueries = this.getList(content.Queries?.ArrayOfQuery?.Query);
-        const queries = rawQueries.sort((a: any, b: any) => (Number(a.Sequence) || 0) - (Number(b.Sequence) || 0));
+        const rawQueries = this.getList(asNode(content.Queries?.ArrayOfQuery)?.Query);
+        const queries = rawQueries.sort((a, b) => (Number(a.Sequence) || 0) - (Number(b.Sequence) || 0));
 
         const finalQuery = queries.length > 0 ? queries[queries.length - 1] : null;
         const intermediateQueries = queries.length > 1 ? queries.slice(0, queries.length - 1) : [];
 
         // Build Table Set from all datasources
-        const allDS = this.getList(content.QueryDatasources?.ArrayOfQueryDatasource?.QueryDatasource);
-        const tableSet = new Set(allDS.map((d: any) => d.DatasourceId || d.DataSourceName).filter(Boolean));
+        const allDS = this.getList(asNode(content.QueryDatasources?.ArrayOfQueryDatasource)?.QueryDatasource);
+        const tableSet = new Set(allDS.map((d) => this.getText(d.DatasourceId || d.DataSourceName)).filter(Boolean));
 
         const stepNotes = dm.stepNotes || {};
 
         // --- Helper: Table Renderer (Updated with Sets) ---
-        const renderTable = (headers: string[], rows: any[], rowIds?: string[]) => {
+        const renderTable = (headers: string[], rows: Record<string, string>[], rowIds?: string[]) => {
             if (!rows || rows.length === 0) return '';
 
-            const ths = headers.map(h => {
-                let w = '';
-                // Specific sizing for Column Table
-                if (h === 'Column') w = 'w-[30%]';
-                else if (h === 'Type' && headers.length === 3) w = 'w-[20%]';
-                else if (h === 'Name' && headers.length === 3) w = 'w-[30%]';
+            const ths = headers
+                .map((h) => {
+                    let w = '';
+                    // Specific sizing for Column Table
+                    if (h === 'Column') w = 'w-[30%]';
+                    else if (h === 'Type' && headers.length === 3) w = 'w-[20%]';
+                    else if (h === 'Name' && headers.length === 3) w = 'w-[30%]';
 
-                return `<th class="px-4 py-2 text-left text-xs font-bold text-slate-700 uppercase tracking-wider bg-slate-200 border-r border-slate-300 last:border-r-0 ${w}">${h}</th>`;
-            }).join('');
+                    return `<th class="px-4 py-2 text-left text-xs font-bold text-slate-700 uppercase tracking-wider bg-slate-200 border-r border-slate-300 last:border-r-0 ${w}">${h}</th>`;
+                })
+                .join('');
 
-            const trs = rows.map((r, idx) => {
-                const cells = headers.map((h, i) => {
-                    let rawVal = r[`Col${i + 1}`] || (i === 0 ? r.Name : r.Value) || '';
+            const trs = rows
+                .map((r, idx) => {
+                    const cells = headers
+                        .map((h, i) => {
+                            let rawVal = r[`Col${i + 1}`] || (i === 0 ? r.Name : r.Value) || '';
 
-                    const isVarName = h === 'Variable Name';
-                    // Don't format merged HTML columns
-                    const isMergedHtml = h === 'Column' || (h === 'Type' && headers.length === 3) || (h === 'Name' && headers.length === 3);
+                            const isVarName = h === 'Variable Name';
+                            // Don't format merged HTML columns
+                            const isMergedHtml =
+                                h === 'Column' ||
+                                (h === 'Type' && headers.length === 3) ||
+                                (h === 'Name' && headers.length === 3);
 
-                    let val = rawVal;
-                    if (!isVarName && !isMergedHtml && !(typeof rawVal === 'string' && rawVal.trim().startsWith('<div'))) {
-                        val = ExpressionFormatter.formatExpression(rawVal, variableSet, tableSet);
-                    }
+                            let val = rawVal;
+                            if (
+                                !isVarName &&
+                                !isMergedHtml &&
+                                !(typeof rawVal === 'string' && rawVal.trim().startsWith('<div'))
+                            ) {
+                                val = ExpressionFormatter.formatExpression(rawVal, variableSet, tableSet);
+                            }
 
-                    const isCode = h === 'Source' || h === 'Formula' || h === 'Expression' || h === 'Value';
+                            const isCode = h === 'Source' || h === 'Formula' || h === 'Expression' || h === 'Value';
 
-                    let cellContent = val;
-                    if (isVarName && rawVal) {
-                        cellContent = `<span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs font-bold border border-purple-200 font-mono">${rawVal}</span>`;
-                    } else if (isCode && val && val !== '-' && !val.toString().includes('<div')) {
-                        cellContent = `<code class="font-mono text-xs bg-slate-50 text-slate-600 border border-slate-200 rounded px-1.5 py-0.5 break-all block">${val}</code>`;
-                    }
+                            let cellContent = val;
+                            if (isVarName && rawVal) {
+                                cellContent = `<span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs font-bold border border-purple-200 font-mono">${rawVal}</span>`;
+                            } else if (isCode && val && val !== '-' && !val.toString().includes('<div')) {
+                                cellContent = `<code class="font-mono text-xs bg-slate-50 text-slate-600 border border-slate-200 rounded px-1.5 py-0.5 break-all block">${val}</code>`;
+                            }
 
-                    const cellClass = (i === 0) ? 'font-medium text-slate-900' : 'text-gray-700';
-                    const alignClass = 'align-top';
-                    const monoClass = (headers.length === 3 && i === 2) ? 'font-mono' : '';
+                            const cellClass = i === 0 ? 'font-medium text-slate-900' : 'text-gray-700';
+                            const alignClass = 'align-top';
+                            const monoClass = headers.length === 3 && i === 2 ? 'font-mono' : '';
 
-                    return `<td class="px-4 py-2 text-sm ${cellClass} ${alignClass} ${monoClass}">${cellContent}</td>`;
-                }).join('');
-                const rowId = rowIds && rowIds[idx] ? ` id="${rowIds[idx]}"` : '';
-                return `<tr class="border-t border-gray-100 hover:bg-gray-50"${rowId}>${cells}</tr>`;
-            }).join('');
+                            return `<td class="px-4 py-2 text-sm ${cellClass} ${alignClass} ${monoClass}">${cellContent}</td>`;
+                        })
+                        .join('');
+                    const rowId = rowIds && rowIds[idx] ? ` id="${rowIds[idx]}"` : '';
+                    return `<tr class="border-t border-gray-100 hover:bg-gray-50"${rowId}>${cells}</tr>`;
+                })
+                .join('');
 
             return `<div class="w-full overflow-hidden border border-slate-300 rounded-md mb-3 min-w-full"><table class="w-full divide-y divide-slate-300 text-left bg-slate-50"><thead><tr class="bg-slate-200">${ths}</tr></thead><tbody class="bg-white divide-y divide-slate-200">${trs}</tbody></table></div>`;
         };
 
         // --- Helper: Summary Generator ---
         const generateSummary = () => {
-            if (!finalQuery) return "No queries defined in this data model.";
+            if (!finalQuery) return 'No queries defined in this data model.';
 
-            const uniqueSources = new Set(allDS.filter((d: any) => d.DataSourceType !== 'Query').map((d: any) => d.DataSourceName || d.TableName)).size;
+            const uniqueSources = new Set(
+                allDS
+                    .filter((d) => d.DataSourceType !== 'Query')
+                    .map((d) => this.getText(d.DataSourceName || d.TableName))
+            ).size;
             const queryCount = queries.length;
 
             // Get columns for final query
-            const finalCols = this.getList(content.QueryColumns?.ArrayOfQueryColumn?.QueryColumn)
-                .filter((c: any) => c.QueryName === finalQuery.QueryName);
+            const finalCols = this.getList(asNode(content.QueryColumns?.ArrayOfQueryColumn)?.QueryColumn).filter(
+                (c) => c.QueryName === finalQuery.QueryName
+            );
 
             return `This Data Model generates the <strong>${finalQuery.QueryName}</strong> dataset. It aggregates data from <strong>${uniqueSources} external sources</strong> across <strong>${queryCount} transformation steps</strong> to produce <strong>${finalCols.length} output columns</strong>.`;
         };
@@ -198,7 +221,9 @@ export class DataModelGenerator {
                 ${summaryHtml}
 
                 <!-- Variables Section -->
-                ${variables.length > 0 ? `
+                ${
+                    variables.length > 0
+                        ? `
                 <details open class="group mb-8">
                      <summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-slate-100 hover:bg-slate-200 transition-colors select-none border-t border-b border-gray-200">
                         <span class="text-xl font-bold text-slate-800 flex items-center gap-3">
@@ -208,26 +233,26 @@ export class DataModelGenerator {
                     </summary>
                     <div class="pt-6 pb-2 px-2">
                         ${(() => {
-                            const varRows = variables.map((v: any) => ({
+                            const varRows = variables.map((v) => ({
                                 Col1: v.Name,
                                 Col2: v.Value,
                                 Col3: v.Type,
                                 Col4: v.Description,
-                                id: v.Name ? `var-${v.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : ''
+                                id: v.Name ? `var-${v.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '',
                             }));
-                            const varIds = varRows.map((r: any) => r.id);
-                            return renderTable(
-                                ['Variable Name', 'Value', 'Type', 'Description'],
-                                varRows,
-                                varIds
-                            );
+                            const varIds = varRows.map((r) => r.id);
+                            return renderTable(['Variable Name', 'Value', 'Type', 'Description'], varRows, varIds);
                         })()}
                     </div>
                 </details>
-                ` : ''}
+                `
+                        : ''
+                }
 
                 <!-- Indexes Section -->
-                ${indexes.length > 0 ? `
+                ${
+                    indexes.length > 0
+                        ? `
                 <details open class="group mb-8">
                      <summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-slate-100 hover:bg-slate-200 transition-colors select-none border-t border-b border-gray-200">
                         <span class="text-xl font-bold text-slate-800 flex items-center gap-3">
@@ -237,20 +262,24 @@ export class DataModelGenerator {
                     </summary>
                     <div class="pt-6 pb-2 px-2">
                          ${(() => {
-                             const indexRows = indexes.map((i: any) => ({
+                             const indexRows = indexes.map((i) => ({
                                  Col1: i.Name,
                                  Col2: i.Columns,
-                                 id: i.Name ? `index-${i.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : ''
+                                 id: i.Name ? `index-${i.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '',
                              }));
-                             const indexIds = indexRows.map((r: any) => r.id);
+                             const indexIds = indexRows.map((r) => r.id);
                              return renderTable(['Index Name', 'Columns'], indexRows, indexIds);
                          })()}
                     </div>
                 </details>
-                ` : ''}
+                `
+                        : ''
+                }
 
                 <!-- Drilldown Views Section -->
-                ${views.length > 0 ? `
+                ${
+                    views.length > 0
+                        ? `
                 <details open class="group mb-8">
                      <summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-slate-100 hover:bg-slate-200 transition-colors select-none border-t border-b border-gray-200">
                         <span class="text-xl font-bold text-slate-800 flex items-center gap-3">
@@ -260,20 +289,24 @@ export class DataModelGenerator {
                     </summary>
                     <div class="pt-6 pb-2 px-2">
                          ${(() => {
-                             const viewRows = views.map((v: any) => ({
+                             const viewRows = views.map((v) => ({
                                  Col1: v.Name,
                                  Col2: v.Columns,
-                                 id: v.Name ? `view-${v.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : ''
+                                 id: v.Name ? `view-${v.Name.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '',
                              }));
-                             const viewIds = viewRows.map((r: any) => r.id);
+                             const viewIds = viewRows.map((r) => r.id);
                              return renderTable(['View Name', 'Columns'], viewRows, viewIds);
                          })()}
                     </div>
                 </details>
-                ` : ''}
+                `
+                        : ''
+                }
 
                  <!-- Final Output Section -->
-                 ${finalQuery ? `
+                 ${
+                     finalQuery
+                         ? `
                     <div class="mt-8">
                          <div class="flex items-center space-x-2 mb-4">
                             <span class="bg-emerald-100 text-emerald-600 p-1.5 rounded-lg">
@@ -285,10 +318,14 @@ export class DataModelGenerator {
                             ${this.renderQueryCard(finalQuery, content, renderTable, variableSet, tableSet, indexMap, true, id, stepNotes)}
                          </div>
                     </div>
-                 ` : ''}
+                 `
+                         : ''
+                 }
 
                  <!-- Transformation Layers -->
-                 ${intermediateQueries.length > 0 ? `
+                 ${
+                     intermediateQueries.length > 0
+                         ? `
                      <div class="mt-12">
                          <div class="flex items-center space-x-2 mb-4 cursor-pointer" onclick="this.nextElementSibling.classList.toggle('hidden')">
                              <div class="bg-blue-50 text-blue-500 p-1 rounded-md">
@@ -299,35 +336,51 @@ export class DataModelGenerator {
                          </div>
                          <div class="hidden">
                             <div class="grid grid-cols-1 gap-6">
-                                ${intermediateQueries.map(q => this.renderQueryCard(q, content, renderTable, variableSet, tableSet, indexMap, false, id, stepNotes)).join('')}
+                                ${intermediateQueries.map((q) => this.renderQueryCard(q, content, renderTable, variableSet, tableSet, indexMap, false, id, stepNotes)).join('')}
                             </div>
                          </div>
                      </div>
-                 ` : ''}
+                 `
+                         : ''
+                 }
             </div>
         `;
     }
 
-    private static renderQueryCard(query: any, content: any, renderTable: (h: string[], r: any[], rowIds?: string[]) => string, variableSet: Set<string>, tableSet: Set<string>, indexMap: Map<string, any>, isFinal: boolean = false, reportId: number = 0, stepNotes: any = {}): string {
-        const qName = query.QueryName;
-        const id = query.Id;
+    private static renderQueryCard(
+        query: XmlNode,
+        content: DataModelParsed,
+        renderTable: (h: string[], r: Record<string, string>[], rowIds?: string[]) => string,
+        variableSet: Set<string>,
+        tableSet: Set<string>,
+        indexMap: Map<string, { Name: string; Columns: string }>,
+        isFinal: boolean = false,
+        reportId: number = 0,
+        stepNotes: Record<string, string> = {}
+    ): string {
+        const qName = this.getText(query.QueryName);
+        const id = this.getText(query.Id);
 
         // Note UI Generation
         const stepNote = stepNotes[id] || '';
         const notesHtml = `
             <div class="step-notes-container mt-2 mb-4" data-step-id="${id}">
-                ${stepNote ? `
+                ${
+                    stepNote
+                        ? `
                     <div class="relative bg-amber-50 border border-amber-200 p-2 rounded text-xs text-amber-900 group/note mb-2">
                         <div class="flex justify-between items-start">
                             <span class="grow italic whitespace-pre-wrap">${ExpressionFormatter.colouriseTextHTML(stepNote, variableSet, tableSet)}</span>
                             <button onclick="window.editStepNote('${reportId}', '${id}')" class="opacity-0 group-hover/note:opacity-100 transition text-amber-600 hover:text-amber-800 ml-2" title="Edit Note">✎</button>
                         </div>
                     </div>
-                ` : `
+                `
+                        : `
                     <button onclick="window.editStepNote('${reportId}', '${id}')" class="text-[10px] text-slate-400 hover:text-blue-500 flex items-center gap-1 transition-colors mt-1">
                         <span>📝</span> Add Note
                     </button>
-                `}
+                `
+                }
                 <div id="note-editor-${id}" class="hidden mt-2">
                     <textarea class="w-full text-xs p-2 border border-blue-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500 outline-none min-h-[60px]" placeholder="Add your technical or business notes here...">${stepNote}</textarea>
                     <div class="flex justify-end gap-2 mt-1">
@@ -339,63 +392,77 @@ export class DataModelGenerator {
         `;
 
         // Find columns
-        const allCols = this.getList(content.QueryColumns?.ArrayOfQueryColumn?.QueryColumn);
-        const myCols = allCols.filter((c: any) => c.QueryName === qName);
+        const allCols = this.getList(asNode(content.QueryColumns?.ArrayOfQueryColumn)?.QueryColumn);
+        const myCols = allCols.filter((c) => this.getText(c.QueryName) === qName);
 
         // Find joins
-        const allJoins = this.getList(content.QueryJoins?.ArrayOfQueryJoin?.QueryJoin);
-        const myJoins = allJoins.filter((j: any) => j.QueryName === qName);
+        const allJoins = this.getList(asNode(content.QueryJoins?.ArrayOfQueryJoin)?.QueryJoin);
+        const myJoins = allJoins.filter((j) => this.getText(j.QueryName) === qName);
 
         // Find datasources
-        const allDS = this.getList(content.QueryDatasources?.ArrayOfQueryDatasource?.QueryDatasource);
-        const myDS = allDS.filter((d: any) => d.QueryName === qName);
+        const allDS = this.getList(asNode(content.QueryDatasources?.ArrayOfQueryDatasource)?.QueryDatasource);
+        const myDS = allDS.filter((d) => this.getText(d.QueryName) === qName);
 
         // Prepare Table Data (Columns)
-        const colRows = myCols.map((c: any) => {
+        const colRows = myCols.map((c) => {
+            const dataSourceName = this.getText(c.DataSourceName);
             let source = '';
             if (c.Expression) {
-                source = c.Expression;
+                source = this.getText(c.Expression);
             } else if (c.DataSourceName && c.FieldId) {
-                source = `<div>${ExpressionFormatter.formatTable(`${c.DataSourceName}.${c.FieldId}`)}</div>`;
+                source = `<div>${ExpressionFormatter.formatTable(`${dataSourceName}.${this.getText(c.FieldId)}`)}</div>`;
             } else {
-                source = c.DataSourceName || '';
+                source = dataSourceName;
             }
 
-            const nameHtml = `<div class="font-medium text-slate-900">${c.ColumnName || 'Unknown Column'}</div>` +
-                (c.Description ? `<div class="text-xs text-gray-500 italic mt-0.5">${ExpressionFormatter.colouriseTextHTML(c.Description, variableSet, tableSet)}</div>` : '');
+            const columnName = this.getText(c.ColumnName);
+            const nameHtml =
+                `<div class="font-medium text-slate-900">${columnName || 'Unknown Column'}</div>` +
+                (c.Description
+                    ? `<div class="text-xs text-gray-500 italic mt-0.5">${ExpressionFormatter.colouriseTextHTML(c.Description, variableSet, tableSet)}</div>`
+                    : '');
 
-            const typeHtml = `<div class="text-slate-700">${c.JavaType || c.DataType || 'String'}</div>` +
-                (c.Format && c.Format !== '-' ? `<div class="text-xs text-gray-500 italic mt-0.5">${c.Format}</div>` : '');
+            const typeHtml =
+                `<div class="text-slate-700">${this.getText(c.JavaType || c.DataType) || 'String'}</div>` +
+                (c.Format && c.Format !== '-'
+                    ? `<div class="text-xs text-gray-500 italic mt-0.5">${this.getText(c.Format)}</div>`
+                    : '');
 
-            const columnId = c.ColumnName ? `col-${c.ColumnName.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
+            const columnId = columnName ? `col-${columnName.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
 
             return {
                 Col1: nameHtml,
                 Col2: typeHtml,
                 Col3: source,
-                id: columnId
+                id: columnId,
             };
         });
-        const colIds = colRows.map((r: any) => r.id);
+        const colIds = colRows.map((r) => r.id);
 
         // Find Filters (Criteria)
-        const filters: { col: string, op: string, val: string, rawOp: string, isIndex: boolean, indexCols?: string }[] = [];
-        const processCriteria = (crit: any) => {
-            if (!crit) return;
-            const values = this.getList(crit.CriteriaValues?.CriteriaValue);
-            values.forEach((v: any) => {
-                if (v.ColumnId && v.Operator?.Value) {
-                    let op = v.Operator.Value;
-                    const rawOp = op; // Store original for tooltip
-                    let val = v.Value1 || '';
+        const filters: { col: string; op: string; val: string; rawOp: string; isIndex: boolean; indexCols?: string }[] =
+            [];
+        const processCriteria = (crit: XmlValue) => {
+            const critNode = asNode(crit);
+            if (!critNode) return;
+            const values = this.getList(asNode(critNode.CriteriaValues)?.CriteriaValue);
+            values.forEach((v) => {
+                const operator = asNode(v.Operator);
+                if (v.ColumnId && operator?.Value) {
+                    const rawOp = this.getText(operator.Value); // Store original for tooltip
+                    let op = rawOp;
+                    let val = this.getText(v.Value1);
 
                     // Refine Operator and Value using Normalization
                     // "Add spaces before any capital letters, then convert all to lower case"
-                    let niceOp = op.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
+                    const niceOp = op
+                        .replace(/([A-Z])/g, ' $1')
+                        .trim()
+                        .toLowerCase();
 
                     // Special Handling for values or specific overrides
                     if (op === 'Between') {
-                        val = `${v.Value1 || '?'} and ${v.Value2 || '?'}`;
+                        val = `${this.getText(v.Value1) || '?'} and ${this.getText(v.Value2) || '?'}`;
                     }
 
                     op = niceOp;
@@ -404,26 +471,28 @@ export class DataModelGenerator {
                     if (val === '') val = '<span class="italic text-gray-400">nothing</span>';
 
                     // Check if col is an Index
-                    const index = indexMap.get(v.ColumnId);
+                    const colId = this.getText(v.ColumnId);
+                    const index = indexMap.get(colId);
 
                     filters.push({
-                        col: v.ColumnId,
+                        col: colId,
                         op: op,
                         val: val,
                         rawOp: rawOp,
                         isIndex: !!index,
-                        indexCols: index ? index.Columns : undefined
+                        indexCols: index ? index.Columns : undefined,
                     });
                 }
             });
-            if (crit.NestedSets?.CriteriaSetItem) {
-                const nested = this.getList(crit.NestedSets.CriteriaSetItem);
-                nested.forEach((n: any) => processCriteria(n));
+            if (asNode(critNode.NestedSets)?.CriteriaSetItem) {
+                const nested = this.getList(asNode(critNode.NestedSets)!.CriteriaSetItem);
+                nested.forEach((n) => processCriteria(n));
             }
         };
 
-        if (query.Criteria?.CriteriaSetItem) {
-            processCriteria(query.Criteria.CriteriaSetItem);
+        const criteria = asNode(query.Criteria);
+        if (criteria?.CriteriaSetItem) {
+            processCriteria(criteria.CriteriaSetItem);
         }
 
         const qDisplayName = qName || '(Unnamed Query)';
@@ -452,81 +521,107 @@ export class DataModelGenerator {
                     
                     ${notesHtml}
 
-                    ${filters.length > 0 ? `
+                    ${
+                        filters.length > 0
+                            ? `
                         <div class="mb-4">
                             <h4 class="text-xs font-bold text-amber-600 uppercase tracking-wider mb-2">Filters</h4>
                              <div class="grid gap-2">
-                                ${filters.map(f => `
+                                ${filters
+                                    .map(
+                                        (f) => `
                                     <div class="bg-amber-50 border border-amber-200 rounded px-3 py-2 flex items-center gap-3 shadow-sm">
                                          <span class="text-amber-500">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"></path></svg>
                                          </span>
                                          <div class="flex items-baseline gap-2 text-sm font-mono break-all flex-1">
-                                             ${f.isIndex
-                                        ? `<div class="flex flex-col"><span class="font-bold text-slate-700 flex items-center gap-1">${f.col}<span class="text-[10px] bg-slate-200 text-slate-600 px-1 rounded uppercase tracking-wider font-sans border border-slate-300">Index</span></span><span class="text-xs text-slate-500 italic block mt-0.5" title="${f.indexCols}">On: ${f.indexCols}</span></div>`
-                                        : `<span class="font-bold text-slate-700">${f.col}</span>`
+                                             ${
+                                                 f.isIndex
+                                                     ? `<div class="flex flex-col"><span class="font-bold text-slate-700 flex items-center gap-1">${f.col}<span class="text-[10px] bg-slate-200 text-slate-600 px-1 rounded uppercase tracking-wider font-sans border border-slate-300">Index</span></span><span class="text-xs text-slate-500 italic block mt-0.5" title="${f.indexCols}">On: ${f.indexCols}</span></div>`
+                                                     : `<span class="font-bold text-slate-700">${f.col}</span>`
                                              }
                                              <span class="text-amber-700 font-medium text-sm px-1 cursor-help border-b border-dotted border-amber-200" title="${f.rawOp}">${f.op}</span>
                                              <span class="text-slate-800 bg-white px-1.5 py-0.5 rounded border border-amber-100 shadow-sm">${f.val}</span>
                                          </div>
                                     </div>
-                                `).join('')}
+                                `
+                                    )
+                                    .join('')}
                             </div>
                         </div>
-                    ` : ''}
+                    `
+                            : ''
+                    }
 
-                    ${showSources ? `
+                    ${
+                        showSources
+                            ? `
                         <div class="mb-6">
                             <h4 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Sources</h4>
                             <div class="flex flex-wrap gap-2">
-                                ${myDS.map((ds: any) => {
-            // Helper to extract real table/query name from parameters
-            const getParamValue = (name: string) => {
-                const fields = this.getList(ds.ParameterValues?.Parameters?.ParameterField);
-                const field = fields.find((f: any) => f.FieldName === name);
-                return field ? field.Value : null;
-            };
+                                ${myDS
+                                    .map((ds) => {
+                                        // Helper to extract real table/query name from parameters
+                                        const getParamValue = (name: string) => {
+                                            const fields = this.getList(
+                                                asNode(asNode(ds.ParameterValues)?.Parameters)?.ParameterField
+                                            );
+                                            const field = fields.find((f) => f.FieldName === name);
+                                            return field ? this.getText(field.Value) : '';
+                                        };
 
-            const realName = getParamValue('TableName') || getParamValue('QueryName') || getParamValue('WarehouseName');
-            const shortName = ds.DataSourceName;
-            const type = ds.DataSourceType || 'Table';
+                                        const realName =
+                                            getParamValue('TableName') ||
+                                            getParamValue('QueryName') ||
+                                            getParamValue('WarehouseName');
+                                        const shortName = this.getText(ds.DataSourceName);
+                                        const type = this.getText(ds.DataSourceType) || 'Table';
 
-            let displayName = shortName || '';
-            if (realName && shortName && realName !== shortName) {
-                displayName = `<span class="font-bold">${shortName}</span> <span class="opacity-70 font-normal ml-1">(${realName})</span>`;
-            } else {
-                displayName = displayName || realName || ds.DatasourceId || 'Unknown Source';
-            }
+                                        let displayName = shortName || '';
+                                        if (realName && shortName && realName !== shortName) {
+                                            displayName = `<span class="font-bold">${shortName}</span> <span class="opacity-70 font-normal ml-1">(${realName})</span>`;
+                                        } else {
+                                            displayName =
+                                                displayName ||
+                                                realName ||
+                                                this.getText(ds.DatasourceId) ||
+                                                'Unknown Source';
+                                        }
 
-            // Style based on type
-            let colorClass = 'bg-gray-100 text-gray-700 border-gray-200';
-            let typeLabel = type.toUpperCase();
+                                        // Style based on type
+                                        let colorClass = 'bg-gray-100 text-gray-700 border-gray-200';
+                                        let typeLabel = type.toUpperCase();
 
-            if (type === 'DirectTable') {
-                colorClass = 'bg-blue-50 text-blue-700 border-blue-200';
-                typeLabel = 'TABLE';
-            } else if (type === 'Warehouse') {
-                colorClass = 'bg-cyan-50 text-cyan-700 border-cyan-200';
-                typeLabel = 'WAREHOUSE';
-            } else if (type === 'Query') {
-                colorClass = 'bg-purple-50 text-purple-700 border-purple-200';
-                typeLabel = 'QUERY';
-            } else if (type === 'Analyser') {
-                colorClass = 'bg-amber-50 text-amber-700 border-amber-200';
-                typeLabel = 'ANALYSER';
-            }
+                                        if (type === 'DirectTable') {
+                                            colorClass = 'bg-blue-50 text-blue-700 border-blue-200';
+                                            typeLabel = 'TABLE';
+                                        } else if (type === 'Warehouse') {
+                                            colorClass = 'bg-cyan-50 text-cyan-700 border-cyan-200';
+                                            typeLabel = 'WAREHOUSE';
+                                        } else if (type === 'Query') {
+                                            colorClass = 'bg-purple-50 text-purple-700 border-purple-200';
+                                            typeLabel = 'QUERY';
+                                        } else if (type === 'Analyser') {
+                                            colorClass = 'bg-amber-50 text-amber-700 border-amber-200';
+                                            typeLabel = 'ANALYSER';
+                                        }
 
-            return `
+                                        return `
                                         <div class="${colorClass} px-3 py-1 rounded border inline-flex items-center font-mono text-xs font-semibold tracking-tight" title="${ds.DatasourceId}">
                                             <span class="opacity-60 text-[9px] mr-2 border-r border-current pr-2 leading-none">${typeLabel}</span>
                                             <span>${displayName}</span>
                                         </div>`;
-        }).join('')}
+                                    })
+                                    .join('')}
                             </div>
                         </div>
-                    ` : ''}
+                    `
+                            : ''
+                    }
 
-                    ${showJoins ? `
+                    ${
+                        showJoins
+                            ? `
                         <div class="mb-6">
                             <h4 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Joins</h4>
                             <div class="overflow-hidden border border-slate-300 rounded-md mb-3">
@@ -540,35 +635,48 @@ export class DataModelGenerator {
                                         </tr>
                                     </thead>
                                     <tbody class="bg-white divide-y divide-slate-200">
-                                        ${myJoins.map((j: any) => `
+                                        ${myJoins
+                                            .map((j) => {
+                                                const ds1 = this.getText(j.DataSource1);
+                                                const ds2 = this.getText(j.DataSource2);
+                                                const left = (ds1 ? ds1 + '.' : '') + (this.getText(j.Field1) || '?');
+                                                const right = (ds2 ? ds2 + '.' : '') + (this.getText(j.Field2) || '?');
+                                                return `
                                             <tr class="hover:bg-slate-50">
-                                                <td class="px-3 py-2 whitespace-nowrap text-xs text-gray-500 font-mono border-r border-slate-100">${j.JoinType || 'Inner'}</td>
-                                                <td class="px-3 py-2 whitespace-nowrap text-sm text-gray-700 font-mono">${ExpressionFormatter.colouriseTextHTML((j.DataSource1 ? j.DataSource1 + '.' : '') + (j.Field1 || '?'), variableSet, tableSet)}</td>
+                                                <td class="px-3 py-2 whitespace-nowrap text-xs text-gray-500 font-mono border-r border-slate-100">${this.getText(j.JoinType) || 'Inner'}</td>
+                                                <td class="px-3 py-2 whitespace-nowrap text-sm text-gray-700 font-mono">${ExpressionFormatter.colouriseTextHTML(left, variableSet, tableSet)}</td>
                                                 <td class="px-3 py-2 whitespace-nowrap text-xs text-gray-400 text-center">=</td>
-                                                <td class="px-3 py-2 whitespace-nowrap text-sm text-gray-700 font-mono">${ExpressionFormatter.colouriseTextHTML((j.DataSource2 ? j.DataSource2 + '.' : '') + (j.Field2 || '?'), variableSet, tableSet)}</td>
+                                                <td class="px-3 py-2 whitespace-nowrap text-sm text-gray-700 font-mono">${ExpressionFormatter.colouriseTextHTML(right, variableSet, tableSet)}</td>
                                             </tr>
-                                        `).join('')}
+                                        `;
+                                            })
+                                            .join('')}
                                     </tbody>
                                 </table>
                             </div>
                         </div>
-                     ` : ''}
+                     `
+                            : ''
+                    }
 
                     <div>
                         <h4 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Columns</h4>
-                        ${renderTable(
-                            ['Name', 'Type', 'Source'],
-            colRows,
-            colIds
-        )}
+                        ${renderTable(['Name', 'Type', 'Source'], colRows, colIds)}
                     </div>
                 </div>
             </details>
         `;
     }
 
-    private static getList(obj: any): any[] {
-        if (!obj) return [];
-        return Array.isArray(obj) ? obj : [obj];
+    private static getList(obj: XmlValue): XmlNode[] {
+        if (obj == null) return [];
+        return (Array.isArray(obj) ? obj : [obj]) as XmlNode[];
+    }
+
+    /** Coerce a leaf XmlValue to a display string ('' for nullish/object/array). */
+    private static getText(val: XmlValue): string {
+        if (val == null) return '';
+        if (typeof val === 'object') return '';
+        return String(val);
     }
 }

--- a/src/lib/generators/DataModelGenerator.ts
+++ b/src/lib/generators/DataModelGenerator.ts
@@ -673,10 +673,17 @@ export class DataModelGenerator {
         return (Array.isArray(obj) ? obj : [obj]) as XmlNode[];
     }
 
-    /** Coerce a leaf XmlValue to a display string ('' for nullish/object/array). */
+    /**
+     * Coerce a leaf XmlValue to a display string. Extracts `#text` when the
+     * value is an attributed node (`{ '@_x': ..., '#text': ... }`); '' for
+     * other objects/arrays/nullish.
+     */
     private static getText(val: XmlValue): string {
         if (val == null) return '';
-        if (typeof val === 'object') return '';
+        if (typeof val === 'object') {
+            const node = asNode(val);
+            return node && typeof node['#text'] === 'string' ? node['#text'] : '';
+        }
         return String(val);
     }
 }

--- a/src/lib/generators/DocxGenerator.ts
+++ b/src/lib/generators/DocxGenerator.ts
@@ -20,6 +20,7 @@ import { EtlParser } from '../parsers/EtlParser';
 import { MermaidGenerator } from './MermaidGenerator';
 import { extractSourcesAndTargets, buildEtlNarrative, plainSummaryFormatter } from './EtlSummary';
 import { createText, createHeaderCell, createCell } from './DocxPrimitives';
+import { asNode } from '../parsers/types';
 
 export class DocxGenerator {
     // --- Helpers (low-level docx primitives live in DocxPrimitives.ts; these
@@ -488,7 +489,7 @@ export class DocxGenerator {
         const metaRows = [
             ['Description', metadata.description],
             ['Version', metadata.version],
-            ['Process Mode', content.DataModel?.DataModelDef?.ProcessMode || 'N/A'],
+            ['Process Mode', String(asNode(content.DataModel?.DataModelDef)?.ProcessMode || 'N/A')],
             ['Last Modified', metadata.dateModified || '-'],
         ];
 
@@ -508,15 +509,15 @@ export class DocxGenerator {
         // 2. Executive Summary
         // Re-implementing logic from DataModelGenerator
         const getList = (obj: any) => (Array.isArray(obj) ? obj : obj ? [obj] : []);
-        const rawQueries = getList(content.Queries?.ArrayOfQuery?.Query).sort(
+        const rawQueries = getList(asNode(content.Queries?.ArrayOfQuery)?.Query).sort(
             (a: any, b: any) => (Number(a.Sequence) || 0) - (Number(b.Sequence) || 0)
         );
         const finalQuery = rawQueries.length > 0 ? rawQueries[rawQueries.length - 1] : null;
-        const allDS = getList(content.QueryDatasources?.ArrayOfQueryDatasource?.QueryDatasource);
+        const allDS = getList(asNode(content.QueryDatasources?.ArrayOfQueryDatasource)?.QueryDatasource);
         const uniqueSources = new Set(
             allDS.filter((d: any) => d.DataSourceType !== 'Query').map((d: any) => d.DataSourceName || d.TableName)
         ).size;
-        const finalCols = getList(content.QueryColumns?.ArrayOfQueryColumn?.QueryColumn).filter(
+        const finalCols = getList(asNode(content.QueryColumns?.ArrayOfQueryColumn)?.QueryColumn).filter(
             (c: any) => c.QueryName === finalQuery?.QueryName
         );
 
@@ -536,7 +537,7 @@ export class DocxGenerator {
         );
 
         // 3. Global Variables (with Source removed per request)
-        const variables = getList(content.Variables?.ArrayOfVariableDef?.VariableDef);
+        const variables = getList(asNode(content.Variables?.ArrayOfVariableDef)?.VariableDef);
         if (variables.length > 0) {
             sections.push(
                 new Paragraph({
@@ -585,7 +586,9 @@ export class DocxGenerator {
         }
 
         // 4. Indexes
-        const indexes = getList(content.DataModel?.Definition?.DataModelDefinition?.Indexes?.Index);
+        const indexes = getList(
+            asNode(asNode(asNode(content.DataModel?.Definition)?.DataModelDefinition)?.Indexes)?.Index
+        );
         if (indexes.length > 0) {
             sections.push(
                 new Paragraph({
@@ -713,7 +716,7 @@ export class DocxGenerator {
             }
 
             // Columns (Name | Type | Source) - 3 Column Layout
-            const myCols = getList(content.QueryColumns?.ArrayOfQueryColumn?.QueryColumn).filter(
+            const myCols = getList(asNode(content.QueryColumns?.ArrayOfQueryColumn)?.QueryColumn).filter(
                 (c: any) => c.QueryName === qName
             );
             if (myCols.length > 0) {
@@ -940,10 +943,10 @@ export class DocxGenerator {
         sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
 
         // 3. Extract data
-        const visualizations = getList(content.Visualisations?.ArrayOfEntityDef?.EntityDef || []);
-        const variables = getList(content.Variables?.ArrayOfVariableDef?.VariableDef || []);
-        const dashLayout = content.Dashboard?.EntityDef?.Definition?.Dashboard || {};
-        const layoutItems = getList(dashLayout.Layout?.LayoutItem || []);
+        const visualizations = getList(asNode(content.Visualisations?.ArrayOfEntityDef)?.EntityDef);
+        const variables = getList(asNode(content.Variables?.ArrayOfVariableDef)?.VariableDef);
+        const dashLayout = asNode(asNode(asNode(content.Dashboard?.EntityDef)?.Definition)?.Dashboard) || {};
+        const layoutItems = getList(asNode(dashLayout.Layout)?.LayoutItem);
 
         // 4. Executive Summary
         const slicerCount = visualizations.filter((v: any) => v.EntitySubType === 'SLICER').length;

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -14,7 +14,7 @@ export class EtlParser {
     }
 
     static getTextSafe(val: XmlValue): string {
-        if (!val) return '';
+        if (val == null || val === '') return '';
         if (typeof val === 'string') return val;
         if (typeof val === 'number' || typeof val === 'boolean') return String(val);
         const node = asNode(val);
@@ -208,18 +208,27 @@ export class EtlParser {
         const stepsRaw = this.getListSafe(asNode(json)?.ArrayOfStep, 'Step') as RawStep[];
         const stepMap = new Map<number, RawStep>();
         const rootSteps: RawStep[] = [];
+        const toInt = (val: XmlValue): number => {
+            const n = parseInt(String(val), 10);
+            return isNaN(n) ? NaN : n;
+        };
         stepsRaw.forEach((step) => {
             step.children = [];
-            stepMap.set(parseInt(String(step.StepId)), step);
+            const stepId = toInt(step.StepId);
+            if (!isNaN(stepId)) stepMap.set(stepId, step);
         });
         stepsRaw.forEach((step) => {
-            const parentId = parseInt(String(step.ParentStepId)) || 0;
+            const parentId = toInt(step.ParentStepId) || 0;
             if (parentId !== 0 && stepMap.has(parentId)) stepMap.get(parentId)!.children!.push(step);
             else rootSteps.push(step);
         });
 
         const sortSteps = (list: RawStep[]) => {
-            list.sort((a, b) => (parseInt(String(a.Sequence)) || 999) - (parseInt(String(b.Sequence)) || 999));
+            const seq = (s: XmlValue) => {
+                const n = toInt(s);
+                return isNaN(n) ? 999 : n;
+            };
+            list.sort((a, b) => seq(a.Sequence) - seq(b.Sequence));
             list.forEach((item) => sortSteps(item.children || []));
         };
         sortSteps(rootSteps);

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -1,17 +1,24 @@
-import type { EtlStep, LogicRule } from './types';
+import type { EtlStep, LogicRule, XmlNode, XmlValue } from './types';
+import { asNode } from './types';
 export type { EtlStep, LogicRule } from './types';
 
+/** A raw XML step node with the `children` array the parser grafts on. */
+type RawStep = XmlNode & { children?: RawStep[] };
+
 export class EtlParser {
-    static getListSafe(obj: any, key: string): any[] {
-        if (!obj || !obj[key]) return [];
-        const val = obj[key];
-        return Array.isArray(val) ? val : [val];
+    static getListSafe(obj: XmlValue, key: string): XmlNode[] {
+        const node = asNode(obj);
+        if (!node || node[key] == null) return [];
+        const val = node[key];
+        return (Array.isArray(val) ? val : [val]) as XmlNode[];
     }
 
-    static getTextSafe(val: any): string {
+    static getTextSafe(val: XmlValue): string {
         if (!val) return '';
         if (typeof val === 'string') return val;
-        if (val['#text']) return val['#text'];
+        if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+        const node = asNode(val);
+        if (node && typeof node['#text'] === 'string') return node['#text'];
         return JSON.stringify(val); // Fallback
     }
 
@@ -76,9 +83,9 @@ export class EtlParser {
         return success && rules.length > 0 ? rules : null;
     }
 
-    static inferLoopPurpose(step: any): string {
-        const children = step.children || [];
-        const types = children.map((c: any) => c.StepType);
+    static inferLoopPurpose(step: XmlNode): string {
+        const children = (step.children as RawStep[] | undefined) || [];
+        const types = children.map((c) => c.StepType);
         if (types.includes('RunDirectQuery') || types.includes('RunTableQuery'))
             return 'Fetching detailed data for each item';
         if (types.includes('ImportWarehouseData')) return 'Saving results for each item';
@@ -86,8 +93,8 @@ export class EtlParser {
         return 'Processing items in batch';
     }
 
-    static extractCriteria(storage: any): string[] {
-        const locations = [
+    static extractCriteria(storage: XmlNode): string[] {
+        const locations: XmlValue[] = [
             storage.Criteria,
             storage.WarehouseCriteria,
             storage.SourceCriteria,
@@ -96,7 +103,16 @@ export class EtlParser {
         ];
         const results: string[] = [];
 
-        locations.forEach((loc) => {
+        locations.forEach((rawLoc) => {
+            if (!rawLoc) return;
+
+            // Handle direct string value
+            if (typeof rawLoc === 'string') {
+                if (rawLoc.trim() !== '') results.push(rawLoc);
+                return;
+            }
+
+            const loc = asNode(rawLoc);
             if (!loc) return;
 
             // Handle CriteriaSetItem structure (nested criteria)
@@ -104,12 +120,12 @@ export class EtlParser {
                 this.processCriteriaSet(loc.CriteriaSetItem, results);
             }
             // Handle direct CriteriaValues
-            else if (loc.CriteriaValues?.CriteriaValue) {
-                const cv = loc.CriteriaValues.CriteriaValue;
-                const list = Array.isArray(cv) ? cv : [cv];
-                list.forEach((c: any) => {
+            else if (asNode(loc.CriteriaValues)?.CriteriaValue) {
+                const cv = asNode(loc.CriteriaValues)!.CriteriaValue;
+                const list = (Array.isArray(cv) ? cv : [cv]) as XmlNode[];
+                list.forEach((c) => {
                     const col = this.getTextSafe(c.ColumnId);
-                    const op = this.getTextSafe(c.Operator?.Value || c.Operator) || '=';
+                    const op = this.getTextSafe(asNode(c.Operator)?.Value || c.Operator) || '=';
                     const val1 = this.getTextSafe(c.Value1);
                     const val2 = this.getTextSafe(c.Value2);
                     if (col) {
@@ -125,28 +141,24 @@ export class EtlParser {
             else if (typeof loc.CriteriaValues === 'string' && loc.CriteriaValues.trim() !== '') {
                 results.push(loc.CriteriaValues);
             }
-            // Handle direct string value
-            else if (typeof loc === 'string' && loc.trim() !== '') {
-                results.push(loc);
-            }
         });
 
         return results;
     }
 
     // Helper to recursively process nested criteria sets
-    private static processCriteriaSet(criteriaSet: any, results: string[]): void {
+    private static processCriteriaSet(criteriaSet: XmlValue, results: string[]): void {
         if (!criteriaSet) return;
 
-        const sets = Array.isArray(criteriaSet) ? criteriaSet : [criteriaSet];
-        sets.forEach((set: any) => {
+        const sets = (Array.isArray(criteriaSet) ? criteriaSet : [criteriaSet]) as XmlNode[];
+        sets.forEach((set) => {
             // Process CriteriaValues in this set
-            if (set.CriteriaValues?.CriteriaValue) {
-                const cv = set.CriteriaValues.CriteriaValue;
-                const list = Array.isArray(cv) ? cv : [cv];
-                list.forEach((c: any) => {
+            if (asNode(set.CriteriaValues)?.CriteriaValue) {
+                const cv = asNode(set.CriteriaValues)!.CriteriaValue;
+                const list = (Array.isArray(cv) ? cv : [cv]) as XmlNode[];
+                list.forEach((c) => {
                     const col = this.getTextSafe(c.ColumnId);
-                    const op = this.getTextSafe(c.Operator?.Value || c.Operator) || '=';
+                    const op = this.getTextSafe(asNode(c.Operator)?.Value || c.Operator) || '=';
                     const val1 = this.getTextSafe(c.Value1);
                     const val2 = this.getTextSafe(c.Value2);
                     if (col) {
@@ -160,13 +172,13 @@ export class EtlParser {
             }
 
             // Recurse into nested sets
-            if (set.NestedSets?.CriteriaSetItem) {
-                this.processCriteriaSet(set.NestedSets.CriteriaSetItem, results);
+            if (asNode(set.NestedSets)?.CriteriaSetItem) {
+                this.processCriteriaSet(asNode(set.NestedSets)!.CriteriaSetItem, results);
             }
         });
     }
 
-    static getExplicitOutput(stepType: string, storage: any, _step: any) {
+    static getExplicitOutput(stepType: string, storage: XmlNode, _step: XmlValue) {
         const target = this.getTextSafe(storage.OutputTableName || storage.TableName || storage.VariableName);
         switch (stepType) {
             case 'ImportWarehouseData':
@@ -192,23 +204,23 @@ export class EtlParser {
      * Main Parsing Method
      * Returns a structured execution tree with metadata, variable usage, and logic rules pre-calculated.
      */
-    static parseSteps(json: any, mode: 'business' | 'technical' = 'technical') {
-        let stepsRaw = this.getListSafe(json?.ArrayOfStep, 'Step');
-        const stepMap = new Map();
-        const rootSteps: any[] = [];
-        stepsRaw.forEach((step: any) => {
+    static parseSteps(json: XmlValue, mode: 'business' | 'technical' = 'technical') {
+        const stepsRaw = this.getListSafe(asNode(json)?.ArrayOfStep, 'Step') as RawStep[];
+        const stepMap = new Map<number, RawStep>();
+        const rootSteps: RawStep[] = [];
+        stepsRaw.forEach((step) => {
             step.children = [];
-            stepMap.set(step.StepId, step);
+            stepMap.set(parseInt(String(step.StepId)), step);
         });
-        stepsRaw.forEach((step: any) => {
-            const parentId = parseInt(step.ParentStepId) || 0;
-            if (parentId !== 0 && stepMap.has(parentId)) stepMap.get(parentId).children.push(step);
+        stepsRaw.forEach((step) => {
+            const parentId = parseInt(String(step.ParentStepId)) || 0;
+            if (parentId !== 0 && stepMap.has(parentId)) stepMap.get(parentId)!.children!.push(step);
             else rootSteps.push(step);
         });
 
-        const sortSteps = (list: any[]) => {
-            list.sort((a, b) => (parseInt(a.Sequence) || 999) - (parseInt(b.Sequence) || 999));
-            list.forEach((item) => sortSteps(item.children));
+        const sortSteps = (list: RawStep[]) => {
+            list.sort((a, b) => (parseInt(String(a.Sequence)) || 999) - (parseInt(String(b.Sequence)) || 999));
+            list.forEach((item) => sortSteps(item.children || []));
         };
         sortSteps(rootSteps);
 
@@ -250,9 +262,9 @@ export class EtlParser {
         };
 
         // 1. Collect Variables & Initial Table Names
-        stepsRaw.forEach((step: any) => {
+        stepsRaw.forEach((step) => {
             const type = step.StepType;
-            const storage = step.Definition?.StorageObject || {};
+            const storage = asNode(asNode(step.Definition)?.StorageObject) || {};
 
             // Collect Table Names
             [
@@ -281,7 +293,7 @@ export class EtlParser {
             if (type === 'SetVariable' || type === 'CalculateVariable') {
                 const vName = this.getTextSafe(storage.VariableName);
                 const vValue = this.getTextSafe(storage.VariableValue || storage.Expression) || '';
-                setVariableValue(vName, vValue, step.Name);
+                setVariableValue(vName, vValue, this.getTextSafe(step.Name));
                 variableNames.add(vName);
             }
 
@@ -302,7 +314,7 @@ export class EtlParser {
 
             if (type === 'Loop' && storage.InputVariable) {
                 const vName = this.getTextSafe(storage.InputVariable);
-                setVariableValue(vName, 'Loop Condition', step.Name);
+                setVariableValue(vName, 'Loop Condition', this.getTextSafe(step.Name));
                 variableNames.add(vName);
             }
         });
@@ -319,20 +331,20 @@ export class EtlParser {
             });
         };
 
-        stepsRaw.forEach((step: any) => {
-            const storage = step.Definition?.StorageObject || {};
+        stepsRaw.forEach((step) => {
+            const storage = asNode(asNode(step.Definition)?.StorageObject) || {};
             registerUsage(JSON.stringify(storage), this.getTextSafe(step.Name));
         });
 
         const columnMetadata = new Map<string, { Type: string; Source: string; Origin: string }>();
-        const registerMetadata = (columns: any[], originStep: string, type: 'Query' | 'Calc' | 'Table') => {
+        const registerMetadata = (columns: XmlNode[], originStep: string, type: 'Query' | 'Calc' | 'Table') => {
             if (!columns) return;
             const cols = Array.isArray(columns) ? columns : [columns];
             cols.forEach((c) => {
                 const name = this.getTextSafe(c.ColumnName);
                 if (!name) return;
                 const dataType = this.getTextSafe(
-                    c.ColumnType?.['#text'] || c.ColumnType || c.ColumnDataType || c.DataType || 'String'
+                    asNode(c.ColumnType)?.['#text'] || c.ColumnType || c.ColumnDataType || c.DataType || 'String'
                 );
                 let source = '';
                 if (type === 'Query') source = this.getTextSafe(c.ColumnSource);
@@ -343,12 +355,12 @@ export class EtlParser {
         };
 
         const executionFlow: EtlStep[] = [];
-        const traverse = (step: any, depth: number): EtlStep | null => {
-            const stepType = step.StepType;
+        const traverse = (step: RawStep, depth: number): EtlStep | null => {
+            const stepType = this.getTextSafe(step.StepType);
             let isActive = step.IsActive !== false;
             // Decisions and Branches are structural logic, so we treat them as active even if marked inactive in XML
             if (stepType === 'Decision' || stepType === 'Branch') isActive = true;
-            const storage = step.Definition?.StorageObject || {};
+            const storage = asNode(asNode(step.Definition)?.StorageObject) || {};
             const stepName = this.getTextSafe(step.Name);
 
             // Metadata Registration
@@ -359,7 +371,7 @@ export class EtlParser {
                     registerMetadata(this.getListSafe(storage.Columns, 'ColumnItemDef'), stepName, 'Calc');
                 else if (stepType === 'CreateTable')
                     registerMetadata(
-                        this.getListSafe(step.OutputTableDefinition?.Columns, 'ColumnItem'),
+                        this.getListSafe(asNode(step.OutputTableDefinition)?.Columns, 'ColumnItem'),
                         stepName,
                         'Table'
                     );
@@ -369,7 +381,7 @@ export class EtlParser {
             let smartDesc = '';
             if (stepType === 'Loop') smartDesc = this.inferLoopPurpose(step);
             if (stepType === 'SetVariable' || stepType === 'CalculateVariable') {
-                const vName = this.getTextSafe(step.Definition?.StorageObject?.VariableName);
+                const vName = this.getTextSafe(asNode(asNode(step.Definition)?.StorageObject)?.VariableName);
                 const usedIn = variableUsage.get(vName);
                 if (usedIn && usedIn.length > 0) {
                     smartDesc = `Used in: ${usedIn.join(', ')}`;
@@ -496,7 +508,7 @@ export class EtlParser {
             const outputs: string[] = [];
 
             // Helper to add if valid string
-            const add = (arr: string[], val: any) => {
+            const add = (arr: string[], val: XmlValue) => {
                 const s = this.getTextSafe(val);
                 if (s && s.trim().length > 0 && !arr.includes(s) && s !== 'dataset' && s !== 'target') arr.push(s);
             };
@@ -590,7 +602,7 @@ export class EtlParser {
                 // Source -> Target
                 let src = table;
                 if (stepType === 'RunDatasourceQuery')
-                    src = this.getTextSafe(storage.DataSource?.Description || 'Datasource');
+                    src = this.getTextSafe(asNode(storage.DataSource)?.Description || 'Datasource');
                 if (stepType === 'RunDirectQuery') src = `Query: ${table}`;
                 fl = `${src} ➔ ${target}`;
             } else if (stepType === 'ImportWarehouseData') {
@@ -600,7 +612,7 @@ export class EtlParser {
             } else if (stepType === 'DeleteWarehouseData') {
                 fl = `Delete Warehouse Data: ${target}`;
             } else if (stepType === 'CreateTable') {
-                const outName = this.getTextSafe(step.OutputTableDefinition?.TableName || 'New Table');
+                const outName = this.getTextSafe(asNode(step.OutputTableDefinition)?.TableName || 'New Table');
                 fl = `Create Table: ${outName}`;
             } else if (stepType === 'AppendTable') {
                 fl = `Append to: ${this.getTextSafe(storage.AppendToTableName || 'Table')}`;
@@ -616,7 +628,7 @@ export class EtlParser {
             if (storage.SortColumns) {
                 const cols = this.getListSafe(storage.SortColumns, 'SortColumnItem');
                 if (cols.length > 0)
-                    info.Details.push(`Sort Order: ${cols.map((c: any) => this.getTextSafe(c.ColumnName)).join(', ')}`);
+                    info.Details.push(`Sort Order: ${cols.map((c) => this.getTextSafe(c.ColumnName)).join(', ')}`);
             }
 
             if (stepType === 'SendEmail') {
@@ -645,11 +657,11 @@ export class EtlParser {
                     storage.Columns,
                     stepType === 'RunTableQuery' ? 'ColumnItem' : 'ColumnItem'
                 );
-                info.TableData = columns.map((c: any) => ({
+                info.TableData = columns.map((c) => ({
                     Col1: this.getTextSafe(c.ColumnName),
                     Col2: this.getTextSafe(c.ColumnSource) || this.getTextSafe(c.ColumnName) || '-',
                     Col3: this.getTextSafe(c.ColumnDataType || c.DataType) || 'String',
-                    Col4: this.getTextSafe(c.ColumnActionType?.['#text'] || c.ColumnActionType) || 'Display',
+                    Col4: this.getTextSafe(asNode(c.ColumnActionType)?.['#text'] || c.ColumnActionType) || 'Display',
                 }));
                 if (info.TableData.length > 0) info.Headers = ['Column Name', 'Source Field', 'Type', 'Action'];
                 // Query limits and aggregations
@@ -662,7 +674,7 @@ export class EtlParser {
                 // Group By
                 const groupByCols = this.getListSafe(storage.GroupByColumns || storage.GroupBy, 'GroupByColumnItem');
                 if (groupByCols.length > 0) {
-                    const groupNames = groupByCols.map((g: any) => this.getTextSafe(g.ColumnName || g)).join(', ');
+                    const groupNames = groupByCols.map((g) => this.getTextSafe(g.ColumnName || g)).join(', ');
                     info.Details.push(`Group By: ${groupNames}`);
                 }
                 // Having
@@ -672,7 +684,7 @@ export class EtlParser {
                 this.extractCriteria(storage).forEach((f) => info.Details.push(`Filter: ${f}`));
             } else if (stepType === 'AddColumn' || stepType === 'UpdateColumn') {
                 const columns = this.getListSafe(storage.Columns, 'ColumnItemDef');
-                info.TableData = columns.map((col: any) => {
+                info.TableData = columns.map((col) => {
                     const rawExpr = this.getTextSafe(col.Expression);
                     // Critical: Parse Logic Rules Here
                     const rules = this.flattenLogic(rawExpr);
@@ -701,7 +713,7 @@ export class EtlParser {
                 info.Headers = ['Variable', 'Expression', 'Type'];
             } else if (stepType === 'ImportWarehouseData') {
                 const mappings = this.getListSafe(storage.ColumnMapping, 'TableColumnMapping');
-                info.TableData = mappings.map((m: any) => {
+                info.TableData = mappings.map((m) => {
                     const cName = this.getTextSafe(m.ColumnName);
                     const sourceVal = this.getTextSafe(m.MappedValue);
                     const sourceCol = sourceVal.replace(/^\[|\]$/g, '');
@@ -721,14 +733,14 @@ export class EtlParser {
                 // Key columns for upsert
                 const keyCols = this.getListSafe(storage.KeyColumns || storage.MatchColumns, 'KeyColumn');
                 if (keyCols.length > 0) {
-                    const keyNames = keyCols.map((k: any) => this.getTextSafe(k.ColumnName || k)).join(', ');
+                    const keyNames = keyCols.map((k) => this.getTextSafe(k.ColumnName || k)).join(', ');
                     info.Details.push(`Key Columns: ${keyNames}`);
                 }
                 // Extract warehouse criteria/filters
                 this.extractCriteria(storage).forEach((f) => info.Details.push(`Filter: ${f}`));
             } else if (stepType === 'JoinTable') {
                 const joins = this.getListSafe(storage.Joins, 'JoinItemDef');
-                info.TableData = joins.map((j: any) => ({
+                info.TableData = joins.map((j) => ({
                     Col1: `${this.getTextSafe(j.JoinTable1)}.${this.getTextSafe(j.JoinColumn1)}`,
                     Col2: `${this.getTextSafe(j.JoinType)} ${this.getTextSafe(j.JoinTable2)}.${this.getTextSafe(j.JoinColumn2)}`,
                 }));
@@ -736,15 +748,15 @@ export class EtlParser {
                 // Extract criteria/filters for join steps
                 this.extractCriteria(storage).forEach((f) => info.Details.push(`Filter: ${f}`));
             } else if (stepType === 'CreateTable') {
-                let outCols = this.getListSafe(step.OutputTableDefinition?.Columns, 'ColumnItem');
+                let outCols = this.getListSafe(asNode(step.OutputTableDefinition)?.Columns, 'ColumnItem');
                 if (outCols.length === 0)
                     outCols = this.getListSafe(
-                        step.OutputTableDefinition?.TableDefinition?.Columns,
+                        asNode(asNode(step.OutputTableDefinition)?.TableDefinition)?.Columns,
                         'TableColumnDefinition'
                     );
-                info.TableData = outCols.map((c: any) => ({
+                info.TableData = outCols.map((c) => ({
                     Col1: this.getTextSafe(c.ColumnName),
-                    Col2: this.getTextSafe(c.ColumnType['#text'] || c.ColumnType) || 'String',
+                    Col2: this.getTextSafe(asNode(c.ColumnType)?.['#text'] || c.ColumnType) || 'String',
                 }));
                 if (info.TableData.length > 0) info.Headers = ['Column Name', 'Type'];
             }
@@ -760,7 +772,7 @@ export class EtlParser {
                     storage.SendEmailAttachmentConfigItems,
                     'SendEmailAttachmentConfigItem'
                 );
-                attachments.forEach((a: any) => {
+                attachments.forEach((a) => {
                     info.Details.push(`Attachment: ${this.getTextSafe(a.FileMask)}`);
                 });
             } else if (stepType === 'LoadTextFile' || stepType === 'SaveText' || stepType === 'SaveTextfile') {
@@ -768,12 +780,13 @@ export class EtlParser {
                 if (file) info.Details.push(`File: ${file}`);
             } else if (stepType === 'RunDatasourceQuery' || stepType === 'RunSimpleQuery') {
                 const dsName =
-                    this.getTextSafe(storage.DataSource?.['@_Description'] || storage.DataSource?.Description) ||
-                    'Datasource';
+                    this.getTextSafe(
+                        asNode(storage.DataSource)?.['@_Description'] || asNode(storage.DataSource)?.Description
+                    ) || 'Datasource';
                 info.Details.push(`Source: ${dsName}`);
 
                 const params = this.getListSafe(storage.DataSourceParameters, 'DataSourceParameterItem');
-                params.forEach((p: any) => {
+                params.forEach((p) => {
                     info.Details.push(
                         `Param: ${this.getTextSafe(p.DataSourceParameterName)} = ${this.getTextSafe(p.DataSourceParameterValue)}`
                     );
@@ -782,11 +795,12 @@ export class EtlParser {
                 if (stepType === 'RunSimpleQuery') {
                     // Reuse table parsing logic for columns
                     const columns = this.getListSafe(storage.Columns, 'ColumnItem');
-                    info.TableData = columns.map((c: any) => ({
+                    info.TableData = columns.map((c) => ({
                         Col1: this.getTextSafe(c.ColumnName),
                         Col2: this.getTextSafe(c.ColumnSource) || this.getTextSafe(c.ColumnName) || '-',
                         Col3: this.getTextSafe(c.ColumnDataType || c.DataType) || 'String',
-                        Col4: this.getTextSafe(c.ColumnActionType?.['#text'] || c.ColumnActionType) || 'Display',
+                        Col4:
+                            this.getTextSafe(asNode(c.ColumnActionType)?.['#text'] || c.ColumnActionType) || 'Display',
                     }));
                     if (info.TableData.length > 0) info.Headers = ['Column Name', 'Source Field', 'Type', 'Action'];
                 }
@@ -834,7 +848,7 @@ export class EtlParser {
                 if (procId && !procName) info.Details.push(`Process ID: ${procId}`);
                 // Process parameters
                 const params = this.getListSafe(storage.Parameters, 'ParameterItem');
-                params.forEach((p: any) => {
+                params.forEach((p) => {
                     info.Details.push(`Param: ${this.getTextSafe(p.Name)} = ${this.getTextSafe(p.Value)}`);
                 });
             }
@@ -849,7 +863,7 @@ export class EtlParser {
                 const sortCols = this.getListSafe(storage.SortColumns, 'SortColumnItem');
                 if (sortCols.length > 0) {
                     const sortInfo = sortCols
-                        .map((c: any) => {
+                        .map((c) => {
                             const colName = this.getTextSafe(c.ColumnName);
                             const direction = this.getTextSafe(c.SortDirection || c.Direction) || 'Asc';
                             return `${colName} ${direction === 'Descending' || direction === 'Desc' ? 'DESC' : 'ASC'}`;
@@ -867,9 +881,7 @@ export class EtlParser {
                 } else {
                     const cols = this.getListSafe(storage.ColumnsToDelete || storage.Columns, 'ColumnItem');
                     if (cols.length > 0) {
-                        info.Details.push(
-                            `Delete: ${cols.map((c: any) => this.getTextSafe(c.ColumnName || c)).join(', ')}`
-                        );
+                        info.Details.push(`Delete: ${cols.map((c) => this.getTextSafe(c.ColumnName || c)).join(', ')}`);
                     }
                 }
             }
@@ -881,32 +893,32 @@ export class EtlParser {
             // 1. DynamicFields (Data Dictionary)
             // Available in queries and most transformations
             const dynFields = this.getListSafe(
-                storage.DynamicFields?.Field || step.OutputTableDefinition?.Columns,
+                asNode(storage.DynamicFields)?.Field || asNode(step.OutputTableDefinition)?.Columns,
                 step.OutputTableDefinition ? 'ColumnItem' : 'Field'
             );
             if (dynFields.length > 0) {
-                info.DataDictionary = dynFields.map((f: any) => {
+                info.DataDictionary = dynFields.map((f) => {
                     // Handle various XML structures for Field definitions
-                    const def = f.FieldDef?.ValueObjectFieldDefinitionOfString || f;
+                    const def = asNode(asNode(f.FieldDef)?.ValueObjectFieldDefinitionOfString) || f;
                     return {
                         Name: this.getTextSafe(f['@_Name'] || f.ColumnName),
                         Type: this.getTextSafe(
-                            def.FieldType || def.ColumnType?.['#text'] || def.ColumnType || 'String'
+                            def.FieldType || asNode(def.ColumnType)?.['#text'] || def.ColumnType || 'String'
                         ),
                         Length: this.getTextSafe(def.MaxLength),
-                        Description: this.getTextSafe(f.Description?.string?.['#text']),
+                        Description: this.getTextSafe(asNode(asNode(f.Description)?.string)?.['#text']),
                     };
                 });
             }
 
             // 2. Exists Filters (Critical Logic)
-            if (storage.ExistsFilters?.ExistsFilterItem) {
+            if (asNode(storage.ExistsFilters)?.ExistsFilterItem) {
                 const exists = this.getListSafe(storage.ExistsFilters, 'ExistsFilterItem');
-                info.ExistsLogic = exists.map((e: any) => {
+                info.ExistsLogic = exists.map((e) => {
                     const table = this.getTextSafe(e.FilterTableName);
                     const notIdx = e.NotExistsFlag === 'true' ? 'NOT ' : '';
                     const links = this.getListSafe(e.Links, 'ExistsFilterItemLink')
-                        .map((l: any) => `${this.getTextSafe(l.FieldName)} = ${this.getTextSafe(l.ColumnName)}`)
+                        .map((l) => `${this.getTextSafe(l.FieldName)} = ${this.getTextSafe(l.ColumnName)}`)
                         .join(' AND ');
                     return `${notIdx}EXISTS IN ${table} WHERE ${links}`;
                 });
@@ -918,7 +930,7 @@ export class EtlParser {
 
             // 4. Import Options
             if (stepType === 'ImportWarehouseData') {
-                const modeCode = this.getTextSafe(storage.ImportOption?.['#text'] || storage.ImportOption);
+                const modeCode = this.getTextSafe(asNode(storage.ImportOption)?.['#text'] || storage.ImportOption);
                 const modeMap: Record<string, string> = {
                     IU: 'Insert or Update',
                     I: 'Insert Only',
@@ -948,7 +960,7 @@ export class EtlParser {
             // We attach them to 'info', ReportGenerator decides display.
 
             executionFlow.push(info);
-            step.children.forEach((child: any) => {
+            (step.children || []).forEach((child) => {
                 const childInfo = traverse(child, depth + 1);
                 if (childInfo) info.children!.push(childInfo);
             });

--- a/src/lib/parsers/types.ts
+++ b/src/lib/parsers/types.ts
@@ -47,17 +47,31 @@ export interface EtlStep {
 }
 
 /**
+ * A single leaf or node value in the raw `fast-xml-parser` tree. Leaves are
+ * strings/numbers/booleans (text and attribute values); interior values are
+ * further {@link XmlNode}s or arrays of values.
+ */
+export type XmlValue = string | number | boolean | XmlNode | XmlValue[] | undefined;
+
+/**
  * Raw output of `fast-xml-parser`. Nodes are arbitrarily nested objects whose
  * leaves are strings (text/attribute values) or further nodes/arrays.
  *
- * The index signature intentionally resolves to `any`: it names the parser
- * boundary shape (replacing bare `any` parameters/returns) without forcing the
- * deferred generator/consumer code — which deep-reads dynamic XML paths like
- * `content.DataModel?.DataModelDef.Definition` — to narrow every access. Those
- * consumers are typed in a follow-up (see issue #19).
+ * The index signature is `XmlValue` (issue #28 tightened it from `any`).
+ * Deep consumers narrow each access via {@link asNode} before reading nested
+ * keys, and funnel leaf reads through `EtlParser.getTextSafe`/`getListSafe`.
  */
 export interface XmlNode {
-    [key: string]: any;
+    [key: string]: XmlValue;
+}
+
+/**
+ * Narrow an {@link XmlValue} to an object node — returns the node when `v` is a
+ * non-array object, otherwise `undefined`. Use to walk dynamic XML paths
+ * (`asNode(content.DataModel)?.DataModelDef`) without scattering `any`.
+ */
+export function asNode(v: XmlValue): XmlNode | undefined {
+    return v != null && typeof v === 'object' && !Array.isArray(v) ? (v as XmlNode) : undefined;
 }
 
 /** Parsed Data Model package (each key is the parsed contents of one XML file). */


### PR DESCRIPTION
Closes #28. Finishes the deep consumer typing deferred from #19.

## What changed
`XmlNode`'s index signature is now `XmlValue` (was `any`). Raw-XML consumers narrow each nested access via a new `asNode()` helper and funnel leaf reads through typed `getText`/`getList`/`getTextSafe`/`getListSafe` helpers. `db.ts` now types `DataModel.content`/`Dashboard.content` as `DataModelParsed`/`DashboardParsed`, which forces the deep `content.X?.Y?.Z` spine in the generators to be typed too — no `any` laundering remains on the DataModel/Dashboard path.

| File | Work |
|------|------|
| `parsers/types.ts` | add `XmlValue` union + `asNode()`; `XmlNode[key]` → `XmlValue` |
| `db.ts` | `content` typed as `DataModelParsed`/`DashboardParsed` |
| `parsers/EtlParser.ts` | `getListSafe`/`getTextSafe` take `XmlValue`; local `RawStep` type for the grafted `children`; `parseInt(String(...))` coercions; ~38 callback `any` removed |
| `generators/DataModelGenerator.ts` | `getList(XmlValue): XmlNode[]`, `asNode` deep chains, string-sink coercions, ~30 callback `any` removed |
| `generators/DashboardGenerator.ts` | same pattern + `escapeHtml` widened to `XmlValue`, `Number()` arithmetic coercions, ~20 callback `any` removed |
| `FileProcessor.ts` / `generators/DocxGenerator.ts` | typed `deepParseAllXml` + `asNode`-wrapped content reads exposed by the `db.ts` change |

## Out of scope (deliberate)
- `EtlStep`'s `[key: string]: any` — parser **output** payload escape hatch (documented in `types.ts`).
- The ETL `Processes.xml` path in `FileProcessor` (`rawProcess: any` DB shape).

## Verification
- `tsc --noEmit` — clean (0 errors)
- `vitest run` — 56/56 across 9 files
- `npm run build` — passes (tsc + vite + service worker)
- `npm run lint` — 0 errors (5 pre-existing unused-catch warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)