### PR TITLE
fix(ci): repair auto-release pnpm install failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "prettier --write"
     ]
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "dexie": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,6 @@
     "vite": "npm:rolldown-vite@7.3.1",
     "vitest": "^4.0.17"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-allowBuilds:
-  esbuild: true
+onlyBuiltDependencies:
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - .
+allowBuilds:
+  esbuild: true
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
@
## Problem

The **Release** workflow has failed at the `Install dependencies` step on every push to `main` since #16, blocking semantic-release (no auto-versioning/changelog/GitHub release). Install error:

```
ERROR  packages field missing or empty
```

## Root cause

#16 added a `pnpm-workspace.yaml` with an invalid `allowBuilds:` key and **no `packages:` field**. pnpm 9 (pinned in the workflow via `version: 9`) treats the file as a workspace manifest and hard-fails when `packages:` is absent. All 5 pushes after #16 failed at install (~10s each, never reaching the release step).

A secondary issue: the workflow pinned pnpm 9 while `package.json` pins `packageManager: pnpm@11.1.2` — version drift between CI and local.

## Fix

- **`pnpm-workspace.yaml`**: replace malformed `allowBuilds:` with the valid `onlyBuiltDependencies:` key. (pnpm 11 had been silently rewriting this file to a `set this to true or false` placeholder on every local install.)
- **`package.json`**: drop the now-duplicate `pnpm.onlyBuiltDependencies` block — pnpm 11 relocates this config to the workspace file.
- **`.github/workflows/release.yml`**: bump `pnpm/action-setup` v3→v4 and remove the hardcoded `version: 9` so CI honors the `packageManager` pin (11.1.2) and stays aligned with local.

## Verification

Local, matching the CI steps:

- `pnpm install --frozen-lockfile` — clean, no nag, file stable (no regen)
- `pnpm test` — 56/56 passing
- `pnpm build` — full build incl. esbuild service-worker step (61 assets cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@