### PR TITLE
fix(app): show package.json version in header (was hardcoded v0.1.0)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ function header() {
                 <h1 class="text-xl font-bold tracking-tight hover:text-blue-300">TechnologyOne Analyser</h1>
             </div>
             <div class="flex items-center">
-                <span class="text-xs text-slate-400 mr-4">v0.1.0 (Testing)</span>
+                <span class="text-xs text-slate-400 mr-4">v${__APP_VERSION__}</span>
 
                 <div id="header-controls" class="flex items-center gap-2">
                     <button onclick="window.verifyOffline()" title="Verify Privacy" class="group bg-emerald-600 hover:bg-emerald-700 text-white p-2 rounded-full font-medium transition-all duration-300 ease-in-out border border-emerald-700 flex items-center shadow-sm">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// Injected at build time by Vite `define` (see vite.config.ts) from package.json version.
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'node:fs'
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
 
 export default defineConfig({
+    define: {
+        __APP_VERSION__: JSON.stringify(version),
+    },
     plugins: [
         tailwindcss(),
     ],


### PR DESCRIPTION
@
## Problem

The auto-release pipeline bumps the version correctly (now `v0.5.1`), but the app header still showed **`v0.1.0 (Testing)`** — the label was hardcoded in `src/main.ts`, disconnected from `package.json`.

## Fix

Inject the version at build time so it always tracks `package.json`:

- **`vite.config.ts`** — read `version` from `package.json` and expose it via Vite `define` as the `__APP_VERSION__` global.
- **`src/main.ts`** — header now interpolates `v${__APP_VERSION__}` (dropped the `(Testing)` suffix now that real releases ship).
- **`src/vite-env.d.ts`** — declares `__APP_VERSION__` for TypeScript.

**No release-workflow change needed.** semantic-release bumps `package.json` and commits the release → Vercel builds that commit → Vite reads the bumped version at build time. The version now updates automatically on every release.

## Verification

- Dev (Vite serve): header renders **`v0.5.1`** (accessibility snapshot confirmed)
- Production build: `v0.5.1</span>` present in the bundle
- `pnpm test` — 56/56 passing
- No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@