### PR TITLE
refactor: remove Business view, unify on single Technical view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**TechnologyOne Analyser** is a web-based utility for analysing, visualising, and documenting Technology One (T1) ETL processes and Data Models. It allows users to upload `.t1etlp` (ETL) and `.t1dm` (Data Model) files, which are then parsed, stored locally (using IndexedDB), and presented in both "Business" and "Technical" views.
+**TechnologyOne Analyser** is a web-based utility for analysing, visualising, and documenting Technology One (T1) ETL processes and Data Models. It allows users to upload `.t1etlp` (ETL) and `.t1dm` (Data Model) files, which are then parsed, stored locally (using IndexedDB), and presented in a detailed technical view.
 
 ## Documentation Index
 
@@ -14,8 +14,8 @@
 
 ### File Format Specifications
 - **[File Formats](./docs/FILE_FORMATS.md)**: Detailed specification of `.t1etlp` and `.t1dm` file formats, XML schemas, and parsing strategies.
-- **[ETL Structure](./docs/ETL_STRUCTURE.md)**: Complete data structure reference for ETL processes - all extracted fields and Business/Technical report exposure.
-- **[Data Model Structure](./docs/DATAMODEL_STRUCTURE.md)**: Complete data structure reference for Data Models - all extracted fields and Business/Technical report exposure.
+- **[ETL Structure](./docs/ETL_STRUCTURE.md)**: Complete data structure reference for ETL processes - all extracted fields and report exposure.
+- **[Data Model Structure](./docs/DATAMODEL_STRUCTURE.md)**: Complete data structure reference for Data Models - all extracted fields and report exposure.
 
 ### Quality & Integration
 - **[Test Coverage Report](./docs/TEST_COVERAGE_REPORT.md)**: Current status of unit testing coverage for core libraries.
@@ -30,14 +30,13 @@
     - **ETL View**: Detailed step-by-step breakdown of ETL processes.
     - **Data Model View**: Visualisation of tables, joins, filters, and sources.
 4.  **Reporting**: Export documentation to Microsoft Word (`.docx`).
-5.  **Views**: Toggle between "Business" (high-level) and "Technical" (detailed) perspectives.
-6.  **Offline Security**: Integrated `OfflineVerifier` ensures zero-data exfiltration by enforcing a physical network disconnect before processing sensitive data.
+5.  **Offline Security**: Integrated `OfflineVerifier` ensures zero-data exfiltration by enforcing a physical network disconnect before processing sensitive data.
 
 ## 📢 Call for Feedback
 
 We are currently acting as a "Beta" for the **ETL** and **Data Model** modules. We specifically seek feedback on:
 
-1.  **ETL Visualisation**: Does the "Business View" accurately summarise your complex ETL processes? Are complex loops and branches rendering logically?
+1.  **ETL Visualisation**: Does the technical view accurately represent your complex ETL processes? Are complex loops and branches rendering logically?
 2.  **Data Model Accuracy**: Are all Tables, Joins, and Filters displaying correctly for your `.t1dm` files?
 3.  **Parsing Edge Cases**: If you have a file that fails to parse or looks "empty", please report it.
 
@@ -58,7 +57,6 @@ We are currently acting as a "Beta" for the **ETL** and **Data Model** modules. 
 - [x] **Data Models (`.t1dm`)**:
     - Visualisation of Tables, Joins, and Sources.
     - Deep parsing of "Query" definitions and variable dependencies.
-    - Business/Technical view toggles.
 - [ ] **Dashboards (`.t1db`)**:
     - Parsing `Dashboard.xml` and `Visualisations.xml` layouts.
     - Visualizing Widget placement and data binding.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -17,7 +17,7 @@ The entry point for handling user uploads.
 ### `EtlParser` (`src/lib/parsers/EtlParser.ts`)
 Responsible for parsing ETL Process definitions.
 
-- **`parseSteps(stepsRaw: any, mode: 'business' | 'technical'): ExecutionFlow`**
+- **`parseSteps(stepsRaw: any): ExecutionFlow`**
   - Converts raw XML/JSON steps into a structured `ExecutionTree`.
   - Handles recursion (Groups, Loops).
   - Extracts used variables and tables into Sets.
@@ -35,7 +35,7 @@ Responsible for parsing Data Model definitions.
 ### `EtlGenerator` (`src/lib/generators/EtlGenerator.ts`)
 Generates HTML views for ETL processes.
 
-- **`generateHtmlView(id: number, viewMode: 'business' | 'technical'): Promise<string>`**
+- **`generateHtmlView(id: number): Promise<string>`**
   - Fetches report from DB.
   - Calls `EtlParser` to get execution flow.
   - Renders Header, Executive Summary, Variables Table, and Recursive Steps.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Responsible for presentation logic.
     -   Accept an ID.
     -   Fetch data from `db`.
     -   Return an **HTML string** representing the detail view.
-    -   Handle "Business" vs "Technical" view logic (hiding/showing specific details).
+    -   Render the full technical detail view (all steps, tables, and SmartDesc insights).
 -   **Docx Generator** (`DocxGenerator.ts`):
     -   Accepts an ID.
     -   Generates a downloadable Microsoft Word document mirroring the detail view.

--- a/docs/DATAMODEL_STRUCTURE.md
+++ b/docs/DATAMODEL_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Data Model Structure
 
-This document describes all data extracted from TechnologyOne Data Model files (`.t1dm`) and indicates which fields are exposed in Business vs Technical reports.
+This document describes all data extracted from TechnologyOne Data Model files (`.t1dm`) and which fields are exposed in the generated reports.
 
 ## Overview
 
@@ -46,15 +46,15 @@ interface DataModel {
 
 ## Metadata Fields
 
-| Field | Source | Business | Technical | Notes |
-|-------|--------|:--------:|:---------:|-------|
-| `name` | `DataModelDef.Description` or filename | Yes | Yes | Display title |
-| `id` | `DataModelDef.DataModelId` | Yes | Yes | GUID identifier |
-| `description` | `DataModelDef.Description` | Yes | Yes | User-provided description |
-| `version` | `DataModelDef.Version` | Yes | Yes | Version number |
-| `owner` | `DataModelDef.Owner` | Yes | Yes | Owner username |
-| `processMode` | `Definition.DataModelDefinition.ProcessMode` | Yes | Yes | `Stored` or `Real-Time` |
-| `dateModified` | Derived | Yes | Yes | Modification timestamp |
+| Field | Source | Exposed | Notes |
+|-------|--------|:-------:|-------|
+| `name` | `DataModelDef.Description` or filename | Yes | Display title |
+| `id` | `DataModelDef.DataModelId` | Yes | GUID identifier |
+| `description` | `DataModelDef.Description` | Yes | User-provided description |
+| `version` | `DataModelDef.Version` | Yes | Version number |
+| `owner` | `DataModelDef.Owner` | Yes | Owner username |
+| `processMode` | `Definition.DataModelDefinition.ProcessMode` | Yes | `Stored` or `Real-Time` |
+| `dateModified` | Derived | Yes | Modification timestamp |
 
 ---
 
@@ -109,13 +109,13 @@ The `content` field contains parsed data from all XML files:
 
 Extracted from `Variables.xml`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `Name` | `VariableDef.Name` | Yes | Yes | Variable identifier |
-| `Value` | `VariableDef.DefaultValue` | Yes | Yes | Default value |
-| `Type` | `VariableDef.DataType` | Yes | Yes | Resolved type name |
-| `Source` | `VariableDef.DataSourceName` | No | Yes | Source if datasource-bound |
-| `Description` | `VariableDef.Description` | Yes | Yes | Variable description |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `Name` | `VariableDef.Name` | Yes | Variable identifier |
+| `Value` | `VariableDef.DefaultValue` | Yes | Default value |
+| `Type` | `VariableDef.DataType` | Yes | Resolved type name |
+| `Source` | `VariableDef.DataSourceName` | Yes | Source if datasource-bound |
+| `Description` | `VariableDef.Description` | Yes | Variable description |
 
 ### Type Resolution
 
@@ -134,10 +134,10 @@ Extracted from `Variables.xml`:
 
 Extracted from `DataModel.Definition.DataModelDefinition.Indexes`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `Name` | `Index.Name` | Yes | Yes | Index identifier |
-| `Columns` | `Index.Columns.Column[].Name` | Yes | Yes | Comma-separated column list |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `Name` | `Index.Name` | Yes | Index identifier |
+| `Columns` | `Index.Columns.Column[].Name` | Yes | Comma-separated column list |
 
 Indexes are used to identify filter columns in criteria (shown with "Index" badge in UI).
 
@@ -147,10 +147,10 @@ Indexes are used to identify filter columns in criteria (shown with "Index" badg
 
 Extracted from `DataModel.Definition.DataModelDefinition.DetailViews`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `Name` | `View.Name` | Yes | Yes | View identifier |
-| `Columns` | `View.Columns.Column[].Name` | Yes | Yes | Comma-separated column list |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `Name` | `View.Name` | Yes | View identifier |
+| `Columns` | `View.Columns.Column[].Name` | Yes | Comma-separated column list |
 
 ---
 
@@ -160,25 +160,25 @@ Queries are sorted by `Sequence` number. The last query is treated as the "Final
 
 ### Query Fields
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `QueryName` | `Query.QueryName` | Yes | Yes | Query identifier |
-| `Id` | `Query.Id` | Yes | Yes | GUID for notes |
-| `Sequence` | `Query.Sequence` | No | Yes | Execution order |
-| `Criteria` | `Query.Criteria.CriteriaSetItem` | Yes | Yes | Filter conditions |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `QueryName` | `Query.QueryName` | Yes | Query identifier |
+| `Id` | `Query.Id` | Yes | GUID for notes |
+| `Sequence` | `Query.Sequence` | Yes | Execution order |
+| `Criteria` | `Query.Criteria.CriteriaSetItem` | Yes | Filter conditions |
 
 ### Query Card Display
 
 Each query is rendered as a collapsible card showing:
 
-| Section | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Header | Yes | Yes | Query name + badges (cols, filters, joins) |
-| Notes | Yes | Yes | User-added annotations |
-| Filters | Yes | Yes | Criteria conditions |
-| Sources | Yes | Yes | Datasource list with types |
-| Joins | Yes | Yes | Join table with type/columns |
-| Columns | Yes | Yes | Column table with name/type/source |
+| Section | Exposed | Content |
+|---------|:-------:|---------|
+| Header | Yes | Query name + badges (cols, filters, joins) |
+| Notes | Yes | User-added annotations |
+| Filters | Yes | Criteria conditions |
+| Sources | Yes | Datasource list with types |
+| Joins | Yes | Join table with type/columns |
+| Columns | Yes | Column table with name/type/source |
 
 ---
 
@@ -186,16 +186,16 @@ Each query is rendered as a collapsible card showing:
 
 Extracted from `QueryColumns.xml`, filtered by `QueryName`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `ColumnName` | `QueryColumn.ColumnName` | Yes | Yes | Output column name |
-| `DataSourceName` | `QueryColumn.DataSourceName` | Yes | Yes | Source datasource |
-| `FieldId` | `QueryColumn.FieldId` | Yes | Yes | Source field name |
-| `Expression` | `QueryColumn.Expression` | Yes | Yes | Calculated expression |
-| `JavaType` | `QueryColumn.JavaType` | Yes | Yes | Primary data type |
-| `DataType` | `QueryColumn.DataType` | Yes | Yes | Fallback data type |
-| `Format` | `QueryColumn.Format` | Yes | Yes | Display format |
-| `Description` | `QueryColumn.Description` | Yes | Yes | Column description |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `ColumnName` | `QueryColumn.ColumnName` | Yes | Output column name |
+| `DataSourceName` | `QueryColumn.DataSourceName` | Yes | Source datasource |
+| `FieldId` | `QueryColumn.FieldId` | Yes | Source field name |
+| `Expression` | `QueryColumn.Expression` | Yes | Calculated expression |
+| `JavaType` | `QueryColumn.JavaType` | Yes | Primary data type |
+| `DataType` | `QueryColumn.DataType` | Yes | Fallback data type |
+| `Format` | `QueryColumn.Format` | Yes | Display format |
+| `Description` | `QueryColumn.Description` | Yes | Column description |
 
 ### Column Source Display Logic
 
@@ -214,13 +214,13 @@ else:
 
 Extracted from `QueryJoins.xml`, filtered by `QueryName`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `JoinType` | `QueryJoin.JoinType` | Yes | Yes | Inner, Left, Right, etc. |
-| `DataSource1` | `QueryJoin.DataSource1` | Yes | Yes | Left datasource |
-| `Field1` | `QueryJoin.Field1` | Yes | Yes | Left field |
-| `DataSource2` | `QueryJoin.DataSource2` | Yes | Yes | Right datasource |
-| `Field2` | `QueryJoin.Field2` | Yes | Yes | Right field |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `JoinType` | `QueryJoin.JoinType` | Yes | Inner, Left, Right, etc. |
+| `DataSource1` | `QueryJoin.DataSource1` | Yes | Left datasource |
+| `Field1` | `QueryJoin.Field1` | Yes | Left field |
+| `DataSource2` | `QueryJoin.DataSource2` | Yes | Right datasource |
+| `Field2` | `QueryJoin.Field2` | Yes | Right field |
 
 ---
 
@@ -228,12 +228,12 @@ Extracted from `QueryJoins.xml`, filtered by `QueryName`:
 
 Extracted from `QueryDatasources.xml`, filtered by `QueryName`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `DataSourceName` | `QueryDatasource.DataSourceName` | Yes | Yes | Alias/short name |
-| `DatasourceId` | `QueryDatasource.DatasourceId` | Yes | Yes | Full identifier |
-| `DataSourceType` | `QueryDatasource.DataSourceType` | Yes | Yes | Type category |
-| `ParameterValues` | `QueryDatasource.ParameterValues` | Yes | Yes | Source parameters |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `DataSourceName` | `QueryDatasource.DataSourceName` | Yes | Alias/short name |
+| `DatasourceId` | `QueryDatasource.DatasourceId` | Yes | Full identifier |
+| `DataSourceType` | `QueryDatasource.DataSourceType` | Yes | Type category |
+| `ParameterValues` | `QueryDatasource.ParameterValues` | Yes | Source parameters |
 
 ### Datasource Types & Styling
 
@@ -264,12 +264,12 @@ This is displayed alongside the alias: `Alias (RealName)`
 
 Criteria are recursively extracted from `Query.Criteria.CriteriaSetItem`:
 
-| Field | Source | Business | Technical | Description |
-|-------|--------|:--------:|:---------:|-------------|
-| `ColumnId` | `CriteriaValue.ColumnId` | Yes | Yes | Filtered column |
-| `Operator` | `CriteriaValue.Operator.Value` | Yes | Yes | Comparison operator |
-| `Value1` | `CriteriaValue.Value1` | Yes | Yes | Primary value |
-| `Value2` | `CriteriaValue.Value2` | Yes | Yes | Secondary value (Between) |
+| Field | Source | Exposed | Description |
+|-------|--------|:-------:|-------------|
+| `ColumnId` | `CriteriaValue.ColumnId` | Yes | Filtered column |
+| `Operator` | `CriteriaValue.Operator.Value` | Yes | Comparison operator |
+| `Value1` | `CriteriaValue.Value1` | Yes | Primary value |
+| `Value2` | `CriteriaValue.Value2` | Yes | Secondary value (Between) |
 
 ### Operator Normalization
 
@@ -318,48 +318,48 @@ to produce ${finalCols.length} output columns.`;
 
 ### Header Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Title | Yes | Yes | `metadata.name` |
-| Description | Yes | Yes | `metadata.description` |
-| Badge | Yes | Yes | "DATA MODEL" |
-| Meta Grid | Yes | Yes | Owner, Version, Process Mode, Date, ID |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Title | Yes | `metadata.name` |
+| Description | Yes | `metadata.description` |
+| Badge | Yes | "DATA MODEL" |
+| Meta Grid | Yes | Owner, Version, Process Mode, Date, ID |
 
 ### Executive Summary
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Summary | Yes | Yes | Auto-generated narrative |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Summary | Yes | Auto-generated narrative |
 
 ### Global Variables Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Table | Yes | Yes | Variable Name, Value, Type, Description |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Table | Yes | Variable Name, Value, Type, Description |
 
 ### Indexes Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Table | Yes | Yes | Index Name, Columns |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Table | Yes | Index Name, Columns |
 
 ### Drilldown Views Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Table | Yes | Yes | View Name, Columns |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Table | Yes | View Name, Columns |
 
 ### Final Output Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Query Card | Yes | Yes | Full query details (expanded by default) |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Query Card | Yes | Full query details (expanded by default) |
 
 ### Transformation Layers Section
 
-| Element | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Query Cards | Yes | Yes | All queries except final (collapsed by default) |
+| Element | Exposed | Content |
+|---------|:-------:|---------|
+| Query Cards | Yes | All queries except final (collapsed by default) |
 
 ---
 
@@ -367,17 +367,17 @@ to produce ${finalCols.length} output columns.`;
 
 The DOCX generator exports the following sections:
 
-| Section | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Header | Yes | Yes | Name as heading |
-| Metadata Table | Yes | Yes | Description, Version, Process Mode, Date |
-| Executive Summary | Yes | Yes | Auto-generated narrative |
-| Global Variables | Yes | Yes | Variable table with Name, Value, Type, Description |
-| Indexes | Yes | Yes | Index table with Name, Columns |
-| Transformation Layers | Yes | Yes | Per-query sections |
-| Query Filters | Yes | Yes | Filter table with Column, Operator, Value |
-| Query Columns | Yes | Yes | Column table with Name/Desc, Type/Format, Source |
-| User Notes | Yes | Yes | Per-query annotations |
+| Section | Exposed | Content |
+|---------|:-------:|---------|
+| Header | Yes | Name as heading |
+| Metadata Table | Yes | Description, Version, Process Mode, Date |
+| Executive Summary | Yes | Auto-generated narrative |
+| Global Variables | Yes | Variable table with Name, Value, Type, Description |
+| Indexes | Yes | Index table with Name, Columns |
+| Transformation Layers | Yes | Per-query sections |
+| Query Filters | Yes | Filter table with Column, Operator, Value |
+| Query Columns | Yes | Column table with Name/Desc, Type/Format, Source |
+| User Notes | Yes | Per-query annotations |
 
 ### DOCX Column Table Format
 

--- a/docs/ETL_STRUCTURE.md
+++ b/docs/ETL_STRUCTURE.md
@@ -1,6 +1,6 @@
 # ETL Process Data Structure
 
-This document describes all data extracted from TechnologyOne ETL Process files (`.t1etlp`) and indicates which fields are exposed in Business vs Technical reports.
+This document describes all data extracted from TechnologyOne ETL Process files (`.t1etlp`) and which fields are exposed in the generated reports.
 
 ## Overview
 
@@ -50,16 +50,16 @@ interface Report {
 
 ## Metadata Fields
 
-| Field | Source | Business | Technical | Notes |
-|-------|--------|:--------:|:---------:|-------|
-| `name` | `Process.Name` | Yes | Yes | Display title |
-| `id` | `Process.ProcessId` | Yes | Yes | GUID identifier |
-| `version` | `Process.Version` | Yes | Yes | Version number |
-| `owner` | `Process.Owner` or narration | Yes | Yes | Extracted from "Published by X" |
-| `description` | `Process.Description` | Yes | Yes | User-provided description |
-| `status` | `Process.Status` | Yes | Yes | P=Published, D=Draft |
-| `narration` | `Process.VersionNarration` | No | Yes | Full version notes |
-| `dateModified` | `Process.DateSaved` | Yes | Yes | Publication timestamp |
+| Field | Source | Exposed | Notes |
+|-------|--------|:-------:|-------|
+| `name` | `Process.Name` | Yes | Display title |
+| `id` | `Process.ProcessId` | Yes | GUID identifier |
+| `version` | `Process.Version` | Yes | Version number |
+| `owner` | `Process.Owner` or narration | Yes | Extracted from "Published by X" |
+| `description` | `Process.Description` | Yes | User-provided description |
+| `status` | `Process.Status` | Yes | P=Published, D=Draft |
+| `narration` | `Process.VersionNarration` | Yes | Full version notes |
+| `dateModified` | `Process.DateSaved` | Yes | Publication timestamp |
 
 ---
 
@@ -69,44 +69,28 @@ The parser builds a hierarchical execution tree from `Steps.xml`. Each step is t
 
 ### ExecutionStep Fields
 
-| Field | Type | Business | Technical | Description |
-|-------|------|:--------:|:---------:|-------------|
-| `id` | string | Yes | Yes | Unique identifier (e.g., `RunDirectQuery_GetData`) |
-| `Step` | string | Yes | Yes | Step name |
-| `RawType` | string | No | Yes | Original step type (e.g., `RunDirectQuery`) |
-| `Phase` | string | Yes | Yes | Formatted step type (may include `[DISABLED]`) |
-| `Context` | string | Yes | Yes | Human-readable purpose description |
-| `SmartDesc` | string | Yes | No | AI-inferred business context |
-| `FlowLabel` | string | Yes | Yes | Label used in Mermaid diagrams |
-| `Description` | string | Yes | Yes | User-provided step description/narration |
-| `IsActive` | boolean | Yes | Yes | Whether step is enabled |
-| `Depth` | number | No | Yes | Nesting level in hierarchy |
-| `Inputs` | string[] | Yes | Yes | Input table/variable names |
-| `Outputs` | string[] | Yes | Yes | Output table/variable names |
-| `Output` | object | Yes | Yes | Explicit output `{type, name}` |
-| `Details` | string[] | Yes | Yes | Additional context (filters, params) |
-| `TableData` | array | Partial | Yes | Column/mapping data tables |
-| `Headers` | string[] | Partial | Yes | Table column headers |
-| `LogicRules` | array | Yes | Yes | Flattened IIF logic chains |
-| `DataDictionary` | array | Yes | Yes | Output column schema |
-| `ExistsLogic` | string[] | Yes | Yes | EXISTS filter conditions |
-| `children` | array | Yes | Yes | Nested child steps |
-
-### Business vs Technical Mode Differences
-
-**Business Mode:**
-- Filters out inactive steps (except structural ones like Loop/Group)
-- Filters out utility steps: `PurgeTable`, `CreateTable`, `DeleteTable`
-- Shows simplified `Context` descriptions (e.g., "Get data from X")
-- Displays `SmartDesc` insights (e.g., "Used in: Step1, Step2")
-- Limits technical detail in tables
-
-**Technical Mode:**
-- Shows all steps including disabled ones
-- Shows raw step types alongside names
-- Shows full technical context (e.g., "Connects to source to pull X")
-- Displays all table data and column mappings
-- Shows variable usage tracking
+| Field | Type | Exposed | Description |
+|-------|------|:-------:|-------------|
+| `id` | string | Yes | Unique identifier (e.g., `RunDirectQuery_GetData`) |
+| `Step` | string | Yes | Step name |
+| `RawType` | string | Yes | Original step type (e.g., `RunDirectQuery`) |
+| `Phase` | string | Yes | Formatted step type (may include `[DISABLED]`) |
+| `Context` | string | Yes | Human-readable purpose description |
+| `SmartDesc` | string | Yes | AI-inferred business context |
+| `FlowLabel` | string | Yes | Label used in Mermaid diagrams |
+| `Description` | string | Yes | User-provided step description/narration |
+| `IsActive` | boolean | Yes | Whether step is enabled |
+| `Depth` | number | Yes | Nesting level in hierarchy |
+| `Inputs` | string[] | Yes | Input table/variable names |
+| `Outputs` | string[] | Yes | Output table/variable names |
+| `Output` | object | Yes | Explicit output `{type, name}` |
+| `Details` | string[] | Yes | Additional context (filters, params) |
+| `TableData` | array | Yes | Column/mapping data tables |
+| `Headers` | string[] | Yes | Table column headers |
+| `LogicRules` | array | Yes | Flattened IIF logic chains |
+| `DataDictionary` | array | Yes | Output column schema |
+| `ExistsLogic` | string[] | Yes | EXISTS filter conditions |
+| `children` | array | Yes | Nested child steps |
 
 ---
 
@@ -114,49 +98,49 @@ The parser builds a hierarchical execution tree from `Steps.xml`. Each step is t
 
 ### Data Extraction Steps
 
-| Step Type | Business Context | Technical Context | TableData |
-|-----------|-----------------|-------------------|-----------|
-| `RunDirectQuery` | "Get data from {table}" | "Connects to source to pull {table}" | Columns: Name, Source, Type, Action |
-| `RunTableQuery` | "Use data from {table}" | "Reads internal {table}" | Columns: Name, Source, Type, Action |
-| `RunDatasourceQuery` | "{source} -> {target}" | "{datasource} -> {target}" | Columns (if RunSimpleQuery) |
-| `RunSimpleQuery` | "{source} -> {target}" | "{datasource} -> {target}" | Columns: Name, Source, Type, Action |
-| `LoadTextFile` | "{step type}" | "Load Text File into {table}" | None |
+| Step Type | Context | TableData |
+|-----------|---------|-----------|
+| `RunDirectQuery` | "Connects to source to pull {table}" | Columns: Name, Source, Type, Action |
+| `RunTableQuery` | "Reads internal {table}" | Columns: Name, Source, Type, Action |
+| `RunDatasourceQuery` | "{datasource} -> {target}" | Columns (if RunSimpleQuery) |
+| `RunSimpleQuery` | "{datasource} -> {target}" | Columns: Name, Source, Type, Action |
+| `LoadTextFile` | "Load Text File into {table}" | None |
 
 ### Transformation Steps
 
-| Step Type | Business Context | Technical Context | TableData |
-|-----------|-----------------|-------------------|-----------|
-| `AddColumn` | "Calculate fields" | "Calculates fields in {table}" | Columns: Field, Formula, Type + LogicRules |
-| `UpdateColumn` | "Update fields" | "Updates values in {table}" | Columns: Field, Formula, Type + LogicRules |
-| `JoinTable` | "Combine with {table2}" | "{step type}" | Joins: Left, Condition |
-| `CreateTable` | Hidden in Business | "Create Table: {name}" | Columns: Name, Type |
-| `AppendTable` | "{step type}" | "Append to: {table}" | None |
+| Step Type | Context | TableData |
+|-----------|---------|-----------|
+| `AddColumn` | "Calculates fields in {table}" | Columns: Field, Formula, Type + LogicRules |
+| `UpdateColumn` | "Updates values in {table}" | Columns: Field, Formula, Type + LogicRules |
+| `JoinTable` | "{step type}" | Joins: Left, Condition |
+| `CreateTable` | "Create Table: {name}" | Columns: Name, Type |
+| `AppendTable` | "Append to: {table}" | None |
 
 ### Variable Steps
 
-| Step Type | Business Context | Technical Context | TableData |
-|-----------|-----------------|-------------------|-----------|
-| `SetVariable` | "{var} = {value}" | "{var} = <code>{value}</code>" | Variable, Expression, Type + LogicRules |
-| `CalculateVariable` | "{var} = {expr}" | "{var} = <code>{expr}</code>" | Variable, Expression, Type + LogicRules |
+| Step Type | Context | TableData |
+|-----------|---------|-----------|
+| `SetVariable` | "{var} = <code>{value}</code>" | Variable, Expression, Type + LogicRules |
+| `CalculateVariable` | "{var} = <code>{expr}</code>" | Variable, Expression, Type + LogicRules |
 
 ### Output Steps
 
-| Step Type | Business Context | Technical Context | TableData |
-|-----------|-----------------|-------------------|-----------|
-| `ImportWarehouseData` | "Save to {target}" | "Save to Warehouse: {target}" | Mappings: Target, Source, Type, Origin |
-| `DeleteWarehouseData` | "Remove data from {target}" | "Delete Warehouse Data: {target}" | None |
-| `ExportToExcel` | "{step type}" | "Export to Excel: {file}" | None |
-| `SendEmail` | "{step type}" | "Email: \"{subject}\"" | None |
-| `SaveText` / `SaveTextfile` | "{step type}" | "Save Text: {file}" | None |
+| Step Type | Context | TableData |
+|-----------|---------|-----------|
+| `ImportWarehouseData` | "Save to Warehouse: {target}" | Mappings: Target, Source, Type, Origin |
+| `DeleteWarehouseData` | "Delete Warehouse Data: {target}" | None |
+| `ExportToExcel` | "Export to Excel: {file}" | None |
+| `SendEmail` | "Email: \"{subject}\"" | None |
+| `SaveText` / `SaveTextfile` | "Save Text: {file}" | None |
 
 ### Control Flow Steps
 
-| Step Type | Business Context | Technical Context | TableData |
-|-----------|-----------------|-------------------|-----------|
-| `Group` | Container | Container | Children rendered inside |
-| `Loop` | "Repeat for {iterator}" | "Repeat for {iterator}" | Children rendered inside |
-| `Decision` | Container | "Decision on {table}" | Children rendered inside |
-| `Branch` | "If {expression}" | "If {expression}" | Children rendered inside |
+| Step Type | Context | TableData |
+|-----------|---------|-----------|
+| `Group` | Container | Children rendered inside |
+| `Loop` | "Repeat for {iterator}" | Children rendered inside |
+| `Decision` | "Decision on {table}" | Children rendered inside |
+| `Branch` | "If {expression}" | Children rendered inside |
 
 ---
 
@@ -166,11 +150,11 @@ Variables are collected from two sources:
 1. **Step-defined variables**: From `SetVariable` and `CalculateVariable` steps
 2. **Loop iterators**: From `Loop` steps with `InputVariable`
 
-| Field | Business Label | Technical Label | Description |
-|-------|---------------|-----------------|-------------|
-| `Name` | "Parameter" | "Variable Name" | Variable identifier |
-| `Value` | "Setting" | "Value / Expression" | Default value or expression |
-| `Type` | N/A | "Type" | `Var` or `Iterator` |
+| Field | Label | Description |
+|-------|-------|-------------|
+| `Name` | "Variable Name" | Variable identifier |
+| `Value` | "Value / Expression" | Default value or expression |
+| `Type` | "Type" | `Var` or `Iterator` |
 
 ---
 
@@ -180,38 +164,38 @@ Variables are collected from two sources:
 
 Extracted from `DynamicFields.Field` or `OutputTableDefinition.Columns`:
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| `Name` | Yes | Yes | Output column name |
-| `Type` | Yes | Yes | Data type |
-| `Length` | Yes | Yes | Max length (if defined) |
-| `Description` | Yes | Yes | Column description |
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| `Name` | Yes | Output column name |
+| `Type` | Yes | Data type |
+| `Length` | Yes | Max length (if defined) |
+| `Description` | Yes | Column description |
 
 ### ExistsLogic (Filters)
 
 Extracted from `ExistsFilters.ExistsFilterItem`:
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| Full expression | Yes | Yes | e.g., "NOT EXISTS IN TableX WHERE Field1 = Column1" |
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| Full expression | Yes | e.g., "NOT EXISTS IN TableX WHERE Field1 = Column1" |
 
 ### Import Options
 
-| Option Code | Meaning | Business | Technical |
-|-------------|---------|:--------:|:---------:|
-| `IU` | Insert or Update | Yes | Yes |
-| `I` | Insert Only | Yes | Yes |
-| `U` | Update Only | Yes | Yes |
-| `D` | Delete | Yes | Yes |
-| `R` | Replace | Yes | Yes |
+| Option Code | Meaning | Exposed |
+|-------------|---------|:-------:|
+| `IU` | Insert or Update | Yes |
+| `I` | Insert Only | Yes |
+| `U` | Update Only | Yes |
+| `D` | Delete | Yes |
+| `R` | Replace | Yes |
 
 ### Criteria/Filters
 
 Extracted from `Criteria`, `WarehouseCriteria`, `SourceCriteria`:
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| Full filter string | Yes | Yes | e.g., "ColumnId = Value1" |
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| Full filter string | Yes | e.g., "ColumnId = Value1" |
 
 ---
 
@@ -242,13 +226,13 @@ Process parameters are runtime inputs that can be set when executing the ETL pro
 
 ### Display Fields
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| `Name` | Yes | Yes | Parameter identifier |
-| `VariableType` | Yes | Yes | Resolved type (String, Numeric, Date, List) |
-| `DefaultValue` | Yes | Yes | Default value if not provided |
-| `Description` | Yes | Yes | User-provided description |
-| `IsMandatory` | Yes | Yes | Required/Optional badge |
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| `Name` | Yes | Parameter identifier |
+| `VariableType` | Yes | Resolved type (String, Numeric, Date, List) |
+| `DefaultValue` | Yes | Default value if not provided |
+| `Description` | Yes | User-provided description |
+| `IsMandatory` | Yes | Required/Optional badge |
 
 ### Type Resolution
 
@@ -289,14 +273,12 @@ File locations define where ETL steps read/write files. They are referenced by s
 
 ### Display Fields
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| `Name` | No | Yes | Location alias |
-| `LocationType` | No | Yes | ServerFolder, FTP, etc. |
-| `Path` | No | Yes | Combined ServerFolder + SubPath |
-| `Description` | No | Yes | User description |
-
-**Note:** File Locations are only shown in Technical mode.
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| `Name` | Yes | Location alias |
+| `LocationType` | Yes | ServerFolder, FTP, etc. |
+| `Path` | Yes | Combined ServerFolder + SubPath |
+| `Description` | Yes | User description |
 
 ---
 
@@ -321,13 +303,13 @@ Attachments are embedded files included with the process (scripts, templates, co
 
 ### Display Fields
 
-| Field | Business | Technical | Description |
-|-------|:--------:|:---------:|-------------|
-| `FileName` | No | Yes | Original filename |
-| `Description` | No | Yes | User description |
-| `Size` | No | Yes | Calculated from Base64 length |
+| Field | Exposed | Description |
+|-------|:-------:|-------------|
+| `FileName` | Yes | Original filename |
+| `Description` | Yes | User description |
+| `Size` | Yes | Calculated from Base64 length |
 
-**Note:** Attachments are only shown in Technical mode. File download is not yet implemented.
+**Note:** File download is not yet implemented.
 
 ---
 
@@ -335,21 +317,21 @@ Attachments are embedded files included with the process (scripts, templates, co
 
 The DOCX generator (`DocxGenerator.ts`) exports the following sections:
 
-| Section | Business | Technical | Content |
-|---------|:--------:|:---------:|---------|
-| Header | Yes | Yes | Name, description |
-| Metadata Table | Yes | Yes | Version, owner, status, date |
-| Executive Summary | Yes | Yes | Auto-generated narrative |
-| Flow Chart | Yes | Yes | Mermaid diagram as PNG |
-| Variables & Parameters | Yes | Yes | Step-derived variable table |
-| Process Parameters | Yes | Yes | Runtime input parameters from Variables.xml |
-| File Locations | No | Yes | File path references from FileLocations.xml |
-| Attachments | No | Yes | Embedded files from Attachments.xml |
-| Process Details | Yes | Yes | Step-by-step breakdown |
-| Step Tables | Partial | Yes | Column mappings, formulas |
-| Data Dictionary | Yes | Yes | Output schema tables |
-| Logic Tables | Yes | Yes | Flattened IIF rules |
-| User Notes | Yes | Yes | Per-step annotations |
+| Section | Exposed | Content |
+|---------|:-------:|---------|
+| Header | Yes | Name, description |
+| Metadata Table | Yes | Version, owner, status, date |
+| Executive Summary | Yes | Auto-generated narrative |
+| Flow Chart | Yes | Mermaid diagram as PNG |
+| Variables & Parameters | Yes | Step-derived variable table |
+| Process Parameters | Yes | Runtime input parameters from Variables.xml |
+| File Locations | Yes | File path references from FileLocations.xml |
+| Attachments | Yes | Embedded files from Attachments.xml |
+| Process Details | Yes | Step-by-step breakdown |
+| Step Tables | Yes | Column mappings, formulas |
+| Data Dictionary | Yes | Output schema tables |
+| Logic Tables | Yes | Flattened IIF rules |
+| User Notes | Yes | Per-step annotations |
 
 ---
 
@@ -357,15 +339,7 @@ The DOCX generator (`DocxGenerator.ts`) exports the following sections:
 
 The `MermaidGenerator` creates flowcharts with these characteristics:
 
-**Business Mode:**
-- Simplified labels
-- Groups/Loops shown as subgraphs
-- Color-coded by step type
-
-**Technical Mode:**
-- Full labels with step types
-- All steps included
-- Detailed flow connections
+Diagrams use full labels with step types, all steps included (including disabled), color-coded by step type, with Groups/Loops rendered as subgraphs.
 
 ---
 

--- a/docs/FILE_FORMATS.md
+++ b/docs/FILE_FORMATS.md
@@ -553,7 +553,7 @@ This section documents what content is currently parsed vs ignored by the applic
 | File | Status | Contents | Contribution Opportunity |
 |------|--------|----------|-------------------------|
 | `Variables.xml` | **NOT PARSED** | Process parameters, default values, picklist definitions | Display variables in ETL view, show parameter dependencies |
-| `FileLocations.xml` | **NOT PARSED** | Server folder references, file paths used by steps | Show file I/O dependencies in technical view |
+| `FileLocations.xml` | **NOT PARSED** | Server folder references, file paths used by steps | Show file I/O dependencies in the report view |
 | `Attachments.xml` | **NOT PARSED** | Embedded file attachments (scripts, templates) | Extract and display attached files |
 | `[Content_Types].xml` | **Ignored** | Standard OPC MIME declarations | Not needed |
 

--- a/docs/GENERATORS.md
+++ b/docs/GENERATORS.md
@@ -22,7 +22,7 @@ This class renders the detailed step-by-step view of an ETL process.
 
 2.  **Header Generation**:
     - Renders title, description, and a metadata grid.
-    - Colour-coded "Business View" or "Technical View" badge.
+    - Colour-coded "Technical View" badge.
 
 3.  **Automatic Summarisation**:
     - Scans the execution tree for key actions (Source extraction, Calculations, Exports).
@@ -34,7 +34,7 @@ This class renders the detailed step-by-step view of an ETL process.
 5.  **Recursive Step Rendering**:
     - Iterates through the execution tree.
     - **Grouping**: Handles nested structures like `loops`, `groups`, and `decisions` by rendering distinct visual containers with icons (e.g., ↻ for loops, ❓ for decisions).
-    - **Contextualisation**: Uses logic to determine if a step is "Technical" or "Business" relevant.
+    - **Contextualisation**: Derives a human-readable context description for each step.
     - **Formatting**: Applies `ExpressionFormatter` to SQL snippets or code blocks to provide syntax highlighting.
     - **Annotations**: Renders user-added "Step Notes" (persisted in DB).
 
@@ -64,7 +64,7 @@ Renders the visual representation of a `.t1dm` file.
 - **Transformation Layers**: Breakdown of intermediate queries leading to the final dataset.
 - **Joins Visualisation**: Renders join logic (e.g., `Left Join TableA.ID = TableB.ID`) in a readable table format.
 - **Filters**: Displays criteria/filters applied to queries (e.g., `Status = 'Active'`).
-- **Interactive Notes**: Allows users to add and persist technical/business notes to specific queries/steps.
+- **Interactive Notes**: Allows users to add and persist notes to specific queries/steps.
 - **Metadata**: Shows Process Mode (Stored vs Live), Indexes, and Global Variables.
 
 ## Shared Utilities

--- a/docs/superpowers/plans/2026-06-07-remove-business-view.md
+++ b/docs/superpowers/plans/2026-06-07-remove-business-view.md
@@ -1,0 +1,580 @@
+# Remove Business View — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the Business/Technical view toggle app-wide, leaving a single unified Technical view that retains the SmartDesc AI-insight badges.
+
+**Architecture:** The toggle is a global `currentMode: 'business' | 'technical'` in `main.ts` threaded as a `mode` argument through every generator (`EtlGenerator`, `DataModelGenerator`, `DashboardGenerator`, `MermaidGenerator`, `DocxGenerator`) and the parser (`EtlParser.parseSteps`). We remove the UI control + state, drop the `mode` parameter from every signature, hard-select the technical code paths (full step set, technical context, technical-only sections always shown), and keep SmartDesc rendering unconditional (SmartDesc is already computed mode-independently in the parser). Docs are updated to drop the Business column / Business-vs-Technical sections.
+
+**Tech Stack:** TypeScript, Vite, Vitest, Dexie (IndexedDB), Mermaid, docx. Tests live in `tests/`, run with `pnpm test`.
+
+**Survivor decisions (locked):**
+- Survivor view = **Technical** + **SmartDesc** badges always on.
+- Parser: always run the technical path — no business filtering (`PurgeTable`/`CreateTable`/`DeleteTable`, inactive steps stay), technical `contextText`.
+- Generators: technical-only sections (File Locations, Attachments, Dashboard params, Dashboard detailed widgets) are **always** rendered.
+- Mermaid: `isTech` is always true — drop business label-simplification and node-skip branches.
+- `EtlSummary.ts` "business calculations" is a plain English string, NOT a mode reference → **no change**.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/main.ts` | Remove `currentMode` state, toggle UI block, `window.setMode`, `setMode` type; drop `mode` args from 4 generator calls + 3 docx calls; fix `dashboardLayout` `parseSteps(..., 'business')` call. |
+| `src/lib/parsers/EtlParser.ts` | Drop `mode` param from `parseSteps`; delete business-filtering block; delete business `contextText` branch (keep technical). |
+| `src/lib/generators/EtlGenerator.ts` | Drop `mode` from `generateHtmlView` + legacy `parseSteps`; remove `mode ===` conditionals (hard-select technical); render SmartDesc + technical details + tech-only sections unconditionally; remove `${mode} VIEW` badge text → `TECHNICAL VIEW` (or drop badge). |
+| `src/lib/generators/DataModelGenerator.ts` | Drop unused `_viewMode` param from `generateHtmlView`. |
+| `src/lib/generators/DashboardGenerator.ts` | Drop `mode` param; always render the two `mode === 'technical'` sections. |
+| `src/lib/generators/MermaidGenerator.ts` | Drop `mode` param from `generateMermaidSyntax`, `renderToSvg`, `getRawSyntax`, `getFlowChartImage`; set `isTech = true`; remove business simplification/skip branches. |
+| `src/lib/generators/DocxGenerator.ts` | Drop `mode` from `downloadDocx` + unused `_mode` from `downloadDataModelDocx`/`downloadDashboardDocx`; always render File Locations + Attachments; render SmartDesc unconditionally; drop `mode` arg to `MermaidGenerator.getFlowChartImage` + `EtlParser.parseSteps`. |
+| `tests/MermaidGenerator.test.ts` | Delete/rewrite business-mode tests; drop `mode` args. |
+| `tests/EtlParser.test.ts`, `tests/EtlParser.KitchenSink.test.ts`, `tests/EtlGenerator.test.ts` | Drop `'technical'` arg from `parseSteps`/`generateHtmlView` calls. |
+| `README.md` | Remove Views feature bullet (#5) + Business View feedback references. |
+| `docs/ETL_STRUCTURE.md` | Collapse Business/Technical columns to single "Exposed" column; remove "Business vs Technical Mode Differences" section. |
+| `docs/DATAMODEL_STRUCTURE.md` | Same doc treatment (verify Business column present first). |
+
+**Suggested execution order:** parser → generators (Etl, Mermaid, DataModel, Dashboard, Docx) → main.ts wiring → tests → docs. Each task below is self-contained; commit after each.
+
+---
+
+### Task 1: EtlParser — drop mode, hard-select technical
+
+**Files:**
+- Modify: `src/lib/parsers/EtlParser.ts`
+- Test: `tests/EtlParser.test.ts`
+
+- [ ] **Step 1: Update the failing test first (drop mode arg)**
+
+In `tests/EtlParser.test.ts`, change every `EtlParser.parseSteps(mockSteps, 'technical')` to `EtlParser.parseSteps(mockSteps)` (5 sites: lines ~77, 108, 126, 152, 166). Also in `tests/EtlParser.KitchenSink.test.ts` line ~42.
+
+- [ ] **Step 2: Run to confirm current state still green (arg is currently optional-compatible)**
+
+Run: `pnpm test -- EtlParser`
+Expected: PASS (calls without arg use the `= 'technical'` default that still exists).
+
+- [ ] **Step 3: Remove the mode parameter**
+
+In `src/lib/parsers/EtlParser.ts`, change the signature:
+
+```typescript
+    static parseSteps(json: XmlValue) {
+        const stepsRaw = this.getListSafe(asNode(json)?.ArrayOfStep, 'Step') as RawStep[];
+```
+
+- [ ] **Step 4: Delete the business-filtering block**
+
+Remove the entire block (around lines 400-410):
+
+```typescript
+            // Business Filtering
+            if (mode === 'business') {
+                const ignore = ['PurgeTable', 'CreateTable', 'DeleteTable'];
+                if (!isActive || ignore.includes(stepType)) {
+                    if (stepType !== 'Loop' && stepType !== 'Group' && stepType !== 'Decision' && stepType !== 'Branch')
+                        // ... (delete the whole if/continue)
+                }
+            }
+```
+
+Delete the complete `if (mode === 'business') { ... }` statement. Read the exact lines in context first (the block ends with a `continue;`-style skip) and remove it wholesale so no orphaned braces remain.
+
+- [ ] **Step 5: Collapse the business contextText branch to technical-only**
+
+Around line 419 there is `if (mode === 'business') { switch (stepType) { ... contextText = ... } }` followed by (or paired with) the technical context assignment. Remove the business branch entirely; keep only the technical `contextText` assignment that was previously the `else`/technical path. Read lines 416-560 first to identify the exact paired structure, then delete only the business arm.
+
+- [ ] **Step 6: Confirm no remaining `mode` references in the file**
+
+Run: `pnpm exec grep -n "mode" src/lib/parsers/EtlParser.ts`
+Expected: only unrelated hits (`modeCode`, `modeMap`, `modeDesc`, `TransactionMode`, `ProcessMode`, `LogLevel`-adjacent) — NO `mode === 'business'` / `mode === 'technical'` / `mode:` param.
+
+- [ ] **Step 7: Run tests**
+
+Run: `pnpm test -- EtlParser`
+Expected: PASS. (KitchenSink asserts on parsed structure; with business filtering gone, the technical path was already the default it ran under, so output is unchanged.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/parsers/EtlParser.ts tests/EtlParser.test.ts tests/EtlParser.KitchenSink.test.ts
+git commit -m "refactor(parser): remove business mode from EtlParser.parseSteps"
+```
+
+---
+
+### Task 2: MermaidGenerator — drop mode, isTech always true
+
+**Files:**
+- Modify: `src/lib/generators/MermaidGenerator.ts`
+- Test: `tests/MermaidGenerator.test.ts`
+
+- [ ] **Step 1: Rewrite the test file to remove business-mode cases**
+
+In `tests/MermaidGenerator.test.ts`:
+- Delete the test `it('filters correctly in business mode', ...)` (~lines 43-64).
+- In the remaining tests, change `MermaidGenerator.generateMermaidSyntax(mockFlow, 'technical')` → `MermaidGenerator.generateMermaidSyntax(mockFlow)` (and the loop/group/decision tests). The group test at ~line 98 used `'business'` — change it to no-arg and update any assertion that depended on business simplification to assert the technical label instead (the node should now render with its full label, no `⚙️`/`🔢` prefix and no skip).
+
+- [ ] **Step 2: Run to confirm it fails (signature still requires mode)**
+
+Run: `pnpm test -- MermaidGenerator`
+Expected: FAIL or type error — tests call with no arg but signature still has required `mode`.
+
+- [ ] **Step 3: Remove mode from all four signatures**
+
+In `src/lib/generators/MermaidGenerator.ts`:
+
+```typescript
+    static generateMermaidSyntax(flow: any[]): string {
+        const isTech = true;
+        let graph = 'flowchart TD\n';
+```
+
+```typescript
+    static async renderToSvg(flow: any[], id: string = 'mermaid-chart'): Promise<string> {
+        await this.initialize();
+        const mermaid = await this.load();
+        const syntax = this.generateMermaidSyntax(flow);
+```
+
+```typescript
+    static getRawSyntax(flow: any[]): string {
+        return this.generateMermaidSyntax(flow);
+    }
+```
+
+```typescript
+    static async getFlowChartImage(flow: any[]): Promise<string> {
+        const svg = await this.renderToSvg(flow, 'mermaid-hidden-' + Date.now());
+```
+
+- [ ] **Step 4: Remove business-only branches**
+
+With `isTech = true` constant, delete the now-dead `if (!isTech) { ... }` branches: the `label = '⚙️' + ...` (~line 171), `label = '🔢' + ...` (~line 176), and the `if (!isTech && ...) { ... return; }` skip block (~lines 180-193). Keep the technical shape/label assignments. Optionally remove the `const isTech = true;` line and any remaining `isTech` references by inlining, but leaving the constant is acceptable and lower-risk — prefer deleting dead `if (!isTech)` branches and keeping `isTech` if other `if (isTech)` branches read cleaner.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm test -- MermaidGenerator`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/generators/MermaidGenerator.ts tests/MermaidGenerator.test.ts
+git commit -m "refactor(mermaid): remove business mode, render technical flow only"
+```
+
+---
+
+### Task 3: EtlGenerator — drop mode, SmartDesc + tech sections always on
+
+**Files:**
+- Modify: `src/lib/generators/EtlGenerator.ts`
+- Test: `tests/EtlGenerator.test.ts`
+
+> **CAUTION:** This file contains pre-existing literal backslash artifacts (`<\p>`, `<\span>`, `\ --- Section ...` comments). Do NOT "fix" these as part of this task — touch only mode-related lines so the diff stays reviewable. They can be cleaned in a separate commit.
+
+- [ ] **Step 1: Update tests to drop the mode arg**
+
+In `tests/EtlGenerator.test.ts`, change every `EtlGenerator.generateHtmlView(<id>, 'technical')` → `EtlGenerator.generateHtmlView(<id>)` (5 sites: lines ~30, 55, 91, 121, 145).
+
+- [ ] **Step 2: Run to confirm still green (default makes arg optional)**
+
+Run: `pnpm test -- EtlGenerator`
+Expected: PASS (mode still defaults; arg now omitted).
+
+- [ ] **Step 3: Remove mode from signatures**
+
+```typescript
+    static async generateHtmlView(reportId: number): Promise<string> {
+        const report = await db.reports.get(reportId);
+        if (!report) return '<p class="text-red-500">Report not found</p>';
+
+        const flowData = EtlParser.parseSteps(report.rawSteps);
+```
+
+And the legacy wrapper:
+
+```typescript
+    static parseSteps(json: any) {
+        return EtlParser.parseSteps(json);
+    }
+```
+
+- [ ] **Step 4: Hard-select technical in every conditional**
+
+Apply each of these (read surrounding context to match exactly):
+
+- `metaGrid`: replace `mode === 'technical' ? (A) : (B)` with just `(A)` (the technical grid).
+- `getRawSyntax(flowData.executionTree, mode)` → `getRawSyntax(flowData.executionTree)`.
+- `Process Flow (${mode})` heading → `Process Flow`.
+- `${mode} VIEW` badge (~line 208) → `TECHNICAL VIEW` (keep the badge styling).
+- Variables table: `Col2: mode === 'technical' ? v.Type || 'Var' : ''` → `Col2: v.Type || 'Var'`; `Col3: mode === 'technical' ? v.OriginStep || '-' : ''` → `Col3: v.OriginStep || '-'`. Header ternary (~line 241) → keep the technical header array.
+- Params: `buildBadges` `if (mode !== 'technical') return '';` → delete that guard (always build badges). `paramRows = mode === 'technical' ? (A) : (B)` → `(A)`. `headers = mode === 'technical' ? (A) : (B)` → `(A)`. `<details ${mode === 'technical' ? 'open' : ''}>` → `<details open>`.
+- File Locations: `if (fileLocations.length > 0 && mode === 'technical')` → `if (fileLocations.length > 0)`.
+- Attachments: `if (attachments.length > 0 && mode === 'technical')` → `if (attachments.length > 0)`.
+- TableData render guard (~line 467): `mode === 'technical' || [..whitelist..].includes(...)` → just render always: `if (item.TableData && item.TableData.length) { ... }` (technical shows all tables anyway, so the whitelist is subsumed).
+- Loop badge (~line 551): `isLoop && mode === 'business' ? <badge> : ''` → `''` (drop the business-only Loop Sequence badge), OR `isLoop ? <badge> : ''` to keep it always. **Choose drop (`''`)** — it was a business-mode affordance.
+- SmartDesc (~line 556): `mode === 'business' && item.SmartDesc ? <span>...` → `item.SmartDesc ? <span>...` (ALWAYS show).
+- RawType span (~line 627): `mode === 'technical' ? <span>(${item.RawType})</span> : ''` → `<span>(${item.RawType})</span>` (always).
+- Second Context/SmartDesc block (~line 634-640): keep the Context div unconditionally; change `mode === 'business' && item.SmartDesc` → `item.SmartDesc`.
+- `mode === 'technical' ? this.renderStepTechnicalDetails(item) : ''` (~line 644) → `this.renderStepTechnicalDetails(item)` (always).
+
+- [ ] **Step 5: Confirm no remaining mode-conditional references**
+
+Run: `pnpm exec grep -n "mode ===" src/lib/generators/EtlGenerator.ts`
+Expected: no matches. Then `pnpm exec grep -n "': 'business'\|'technical'" src/lib/generators/EtlGenerator.ts` — only the (now-removed) — expect none for the union type param.
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `pnpm test -- EtlGenerator`
+Expected: PASS.
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors in EtlGenerator.ts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/generators/EtlGenerator.ts tests/EtlGenerator.test.ts
+git commit -m "refactor(etl-view): remove business mode, keep SmartDesc always on"
+```
+
+---
+
+### Task 4: DataModelGenerator — drop unused mode param
+
+**Files:**
+- Modify: `src/lib/generators/DataModelGenerator.ts`
+- Test: `tests/DataModelGenerator.test.ts` (already calls no-arg — no change expected)
+
+- [ ] **Step 1: Remove the unused param**
+
+```typescript
+    static async generateHtmlView(id: number): Promise<string> {
+        const dm = await db.dataModels.get(id);
+        if (!dm) throw new Error('Data Model not found');
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm test -- DataModelGenerator`
+Expected: PASS (tests already call `generateHtmlView(202)` etc. with no mode).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/generators/DataModelGenerator.ts
+git commit -m "refactor(datamodel-view): drop unused viewMode param"
+```
+
+---
+
+### Task 5: DashboardGenerator — drop mode, always show tech sections
+
+**Files:**
+- Modify: `src/lib/generators/DashboardGenerator.ts`
+- Test: none dedicated (verify via tsc + manual). If a dashboard fixture test exists, update calls.
+
+- [ ] **Step 1: Remove the param**
+
+```typescript
+    static async generateHtmlView(id: number): Promise<string> {
+        const dashboard = await db.dashboards.get(id);
+        if (!dashboard) throw new Error('Dashboard not found');
+```
+
+- [ ] **Step 2: Always render the two technical sections**
+
+- `if (dashParamsList.length > 0 && mode === 'technical')` (~line 204) → `if (dashParamsList.length > 0)`.
+- `if (visualizations.length > 0 && mode === 'technical')` (~line 265) → `if (visualizations.length > 0)`.
+- Update the comment `// --- Detailed Widgets Section (Technical View Only) ---` → `// --- Detailed Widgets Section ---`.
+
+- [ ] **Step 3: Confirm no remaining mode references**
+
+Run: `pnpm exec grep -n "mode" src/lib/generators/DashboardGenerator.ts`
+Expected: no `mode ===` / `mode:` param hits.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors in DashboardGenerator.ts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/generators/DashboardGenerator.ts
+git commit -m "refactor(dashboard-view): remove business mode, show all sections"
+```
+
+---
+
+### Task 6: DocxGenerator — drop mode, always export full detail + SmartDesc
+
+**Files:**
+- Modify: `src/lib/generators/DocxGenerator.ts`
+- Test: none dedicated (verify via tsc).
+
+- [ ] **Step 1: Remove params from the three download methods**
+
+```typescript
+    static async downloadDocx(reportId: number) {
+        const report = await db.reports.get(reportId);
+        if (!report) throw new Error('Report not found');
+
+        const flowData = EtlParser.parseSteps(report.rawSteps);
+```
+
+```typescript
+    static async downloadDataModelDocx(id: number) {
+```
+
+```typescript
+    static async downloadDashboardDocx(id: number) {
+```
+
+- [ ] **Step 2: Drop mode from the Mermaid call**
+
+`MermaidGenerator.getFlowChartImage(flowData.executionTree, mode)` → `MermaidGenerator.getFlowChartImage(flowData.executionTree)`.
+
+- [ ] **Step 3: Always render File Locations + Attachments**
+
+The block `if (mode === 'technical') { ... File Locations ... Attachments ... }` (~lines 191-...) — remove the `if (mode === 'technical')` wrapper, keeping its body (the File Locations and Attachments sub-blocks) executing unconditionally. Read the block to find its closing brace and de-indent / unwrap correctly.
+
+- [ ] **Step 4: Always render SmartDesc**
+
+`if (mode === 'business' && item.SmartDesc) {` (~line 299) → `if (item.SmartDesc) {`.
+
+- [ ] **Step 5: Confirm no remaining mode references**
+
+Run: `pnpm exec grep -n "mode" src/lib/generators/DocxGenerator.ts`
+Expected: no `mode ===` / `mode:` param hits (string `'Mode: ...'` Detail literals and `ProcessMode`/`TransactionMode` are fine).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors in DocxGenerator.ts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/generators/DocxGenerator.ts
+git commit -m "refactor(docx): remove business mode, always export full detail + SmartDesc"
+```
+
+---
+
+### Task 7: main.ts — remove toggle UI, state, and thread-through
+
+**Files:**
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Remove the mode state**
+
+Delete line: `let currentMode: 'business' | 'technical' = 'business';` (~line 34).
+
+- [ ] **Step 2: Fix the dashboard summary parse call**
+
+`EtlParser.parseSteps(r.rawSteps, 'business')` (~line 85) → `EtlParser.parseSteps(r.rawSteps)`.
+
+- [ ] **Step 3: Remove the toggle UI block**
+
+Delete the `<div class="bg-white p-1 rounded-xl ...">` containing the two `mode-btn` buttons (~lines 189-192) in the detail toolbar.
+
+- [ ] **Step 4: Drop mode from the three generator HTML calls**
+
+```typescript
+            if (currentType === 'report') {
+                html = await EtlGenerator.generateHtmlView(currentReportId);
+            } else if (currentType === 'datamodel') {
+                html = await DataModelGenerator.generateHtmlView(currentReportId);
+            } else if (currentType === 'dashboard') {
+                html = await DashboardGenerator.generateHtmlView(currentReportId);
+            }
+```
+
+- [ ] **Step 5: Remove setMode (window decl, type, and impl)**
+
+- Delete `setMode: (mode: 'business' | 'technical') => void;` from the `Window` interface (~line 316).
+- Delete the `window.setMode = (mode) => { currentMode = mode; render(); };` block (~lines 335-338).
+
+- [ ] **Step 6: Drop mode from the three docx download calls**
+
+```typescript
+            if (currentType === 'report') {
+                await DocxGenerator.downloadDocx(currentReportId);
+            } else if (currentType === 'datamodel') {
+                await DocxGenerator.downloadDataModelDocx(currentReportId);
+            } else if (currentType === 'dashboard') {
+                await DocxGenerator.downloadDashboardDocx(currentReportId);
+            }
+```
+
+- [ ] **Step 7: Confirm clean**
+
+Run: `pnpm exec grep -n "currentMode\|setMode\|'business'\|mode-btn" src/main.ts`
+Expected: no matches.
+
+- [ ] **Step 8: Typecheck + full test run**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors.
+Run: `pnpm test`
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "refactor(ui): remove business/technical view toggle"
+```
+
+---
+
+### Task 8: Optional CSS cleanup — `.mode-btn`
+
+**Files:**
+- Modify: whichever CSS file defines `.mode-btn` (search first).
+
+- [ ] **Step 1: Find the rule**
+
+Run: `pnpm exec grep -rn "mode-btn" src/`
+Expected: if matches remain only in a CSS/style file, remove the `.mode-btn` and `.mode-btn.active` rules. If no matches, skip this task.
+
+- [ ] **Step 2: Commit (only if a change was made)**
+
+```bash
+git add -A
+git commit -m "chore(css): remove dead .mode-btn styles"
+```
+
+---
+
+### Task 9: Docs — README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Remove the Views feature bullet**
+
+Delete bullet #5 under **Key Features**:
+`5.  **Views**: Toggle between "Business" (high-level) and "Technical" (detailed) perspectives.`
+Renumber the following bullet (Offline Security) if numbering matters, or leave as a bulleted list.
+
+- [ ] **Step 2: Update the Call for Feedback section**
+
+In **📢 Call for Feedback**, item 1 references `"Business View"`:
+`1.  **ETL Visualisation**: Does the "Business View" accurately summarise...`
+Reword to drop the Business View framing, e.g.:
+`1.  **ETL Visualisation**: Does the technical view accurately represent your complex ETL processes? Are complex loops and branches rendering logically?`
+
+- [ ] **Step 3: Update the Roadmap Data Models bullet**
+
+Under **📊 Module: BI & Analytics**, remove the sub-bullet:
+`- Business/Technical view toggles.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): remove business view references"
+```
+
+---
+
+### Task 10: Docs — ETL_STRUCTURE.md
+
+**Files:**
+- Modify: `docs/ETL_STRUCTURE.md`
+
+- [ ] **Step 1: Collapse Business/Technical table columns**
+
+Every table with `| Business | Technical |` paired columns (Metadata Fields, ExecutionStep Fields, Step Types tables, Variables Collection, DataDictionary, ExistsLogic, Import Options, Criteria, Process Parameters, File Locations, Attachments, DOCX Export sections) should collapse to a single column. Convert the two columns into one `| Exposed |` (or remove the columns entirely where every row was "Yes/Yes"). For rows previously `Business: No / Technical: Yes` (e.g. `RawType`, `Depth`, `narration`, File Locations, Attachments), they are now always exposed → `Yes`. For rows previously `Business: Yes / Technical: No` (`SmartDesc`), still exposed → `Yes`.
+
+Practical approach: replace each `| Business | Technical |` header pair with a single `| Exposed |` column and set each cell to `Yes` (everything is now shown), EXCEPT note that `SmartDesc` and technical-only fields are all surfaced in the single view.
+
+- [ ] **Step 2: Remove the "Business vs Technical Mode Differences" section**
+
+Delete the entire `### Business vs Technical Mode Differences` block (the **Business Mode:** / **Technical Mode:** bullet lists, ~lines 95-110).
+
+- [ ] **Step 3: Remove Business/Technical split in the Mermaid Diagram Generation section**
+
+Delete the `**Business Mode:**` vs `**Technical Mode:**` bullet split (~lines 360-369); replace with a single description of the technical flowchart (full labels, all steps, color-coded by type).
+
+- [ ] **Step 4: Remove the "Business Context" column from Step Types tables**
+
+The Step Type tables have `| Business Context | Technical Context |`. Collapse to a single `| Context |` column using the Technical Context value. Drop "Hidden in Business" notes (e.g. `CreateTable` row).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ETL_STRUCTURE.md
+git commit -m "docs(etl-structure): remove business/technical split"
+```
+
+---
+
+### Task 11: Docs — DATAMODEL_STRUCTURE.md
+
+**Files:**
+- Modify: `docs/DATAMODEL_STRUCTURE.md`
+
+- [ ] **Step 1: Inspect for Business columns**
+
+Run: `pnpm exec grep -n "Business" docs/DATAMODEL_STRUCTURE.md`
+If matches exist, apply the same collapse treatment as Task 10 (paired columns → single `Exposed`; remove any Business-vs-Technical narrative section). If no matches, skip and note "no changes needed".
+
+- [ ] **Step 2: Commit (only if changed)**
+
+```bash
+git add docs/DATAMODEL_STRUCTURE.md
+git commit -m "docs(datamodel-structure): remove business/technical split"
+```
+
+---
+
+### Task 12: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full grep sweep for stragglers**
+
+Run: `pnpm exec grep -rni "business" src/`
+Expected: only the EtlSummary `performs business calculations` string literal (intentional). Anything else → investigate.
+
+Run: `pnpm exec grep -rn "'business' | 'technical'\|mode ===" src/`
+Expected: no matches.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pnpm test`
+Expected: all PASS.
+
+- [ ] **Step 4: Build**
+
+Run: `pnpm build`
+Expected: build succeeds (`tsc && vite build && node scripts/build-sw.js`).
+
+- [ ] **Step 5: Manual smoke (preview)**
+
+Run: `pnpm dev`, open the app, upload a `.t1etlp`, confirm: no toggle in toolbar; ETL detail renders with full steps + 💡 SmartDesc badges + RawType labels + File Locations/Attachments; DOCX export works. Repeat for `.t1dm` and `.t1db`.
+
+- [ ] **Step 6: Final commit (if any verification fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore: verification fixes for business-view removal"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Scope = all modules (Tasks 1-7 cover ETL parser/view, Mermaid, DataModel, Dashboard, Docx, main UI). Survivor = technical + SmartDesc (Tasks 1,3,6 keep SmartDesc unconditional; technical paths hard-selected). Docs (Tasks 9-11). Tests (folded into 1,2,3). ✅
+- **`EtlSummary.ts`:** intentionally untouched — `business` there is an English word, not a mode. Flagged in Task 12 grep as expected.
+- **Pre-existing file artifacts** (`<\p>`, `\ ---`) in EtlGenerator/DataModelGenerator: out of scope, flagged caution in Task 3.
+- **Type consistency:** `parseSteps(json)`, `generateHtmlView(id)`, `getFlowChartImage(flow)`, `getRawSyntax(flow)`, `generateMermaidSyntax(flow)`, `downloadDocx(id)` — all single-arg after refactor; call sites updated in Tasks 3,6,7. ✅
+- **Risk:** removing the parser business-filter changes dashboard summary input (now includes utility/inactive steps). `generateSummary` summarizes sources/targets, not step count, so output is stable — verified by reading `EtlSummary.ts` (no mode/count dependency).

--- a/src/lib/formatters/ExpressionFormatter.ts
+++ b/src/lib/formatters/ExpressionFormatter.ts
@@ -1,18 +1,35 @@
-
 // --- Helper Types ---
-export type LogicRule = { outcome: string, condition: string };
+export type LogicRule = { outcome: string; condition: string };
 
 export class ExpressionFormatter {
-
     static escapeRegExp(string: string) {
         return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
     /**
+     * Escapes HTML special characters for safe interpolation into innerHTML.
+     * Use for plain-text, file-derived values that are NOT run through colouriseTextHTML.
+     */
+    static escapeHtml(value: any): string {
+        if (value === null || value === undefined) return '';
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    /**
      * Colourises text by highlighting variables and tables found in the respective sets.
      */
-    static colouriseTextHTML(text: any, varSet: Set<string>, tableSet: Set<string> = new Set(), stepSet: Set<string> = new Set()): string {
-        if (text === null || text === undefined) return "";
+    static colouriseTextHTML(
+        text: any,
+        varSet: Set<string>,
+        tableSet: Set<string> = new Set(),
+        stepSet: Set<string> = new Set()
+    ): string {
+        if (text === null || text === undefined) return '';
         let str = String(text);
 
         // Placeholder strategy to prevent double wrapping
@@ -31,12 +48,12 @@ export class ExpressionFormatter {
 
         // 2. Handle generic variable names found in the set
         if (varSet.size > 0) {
-            const varPatterns = Array.from(varSet).map(v => {
+            const varPatterns = Array.from(varSet).map((v) => {
                 const esc = this.escapeRegExp(v);
                 return `\\[?${esc}\\]?`;
             });
             const varRegex = new RegExp(`(?<!\\w)(${varPatterns.join('|')})(?!\\w)`, 'g');
- 
+
             str = str.replace(varRegex, (match) => {
                 const varName = match.replace(/^\[|\]$/g, '');
                 return createPlaceholder(`<span class="var-badge">${varName}</span>`, 'var');
@@ -45,7 +62,7 @@ export class ExpressionFormatter {
 
         // 3. Handle table names found in the table set
         if (tableSet.size > 0) {
-            const tablePatterns = Array.from(tableSet).map(t => {
+            const tablePatterns = Array.from(tableSet).map((t) => {
                 const esc = this.escapeRegExp(t);
                 return `\\[?${esc}\\]?`;
             });
@@ -58,7 +75,7 @@ export class ExpressionFormatter {
 
         // 4. Handle step output names (Strings from LoadText etc)
         if (stepSet.size > 0) {
-            const stepPatterns = Array.from(stepSet).map(s => {
+            const stepPatterns = Array.from(stepSet).map((s) => {
                 const esc = this.escapeRegExp(s);
                 return `\\[?${esc}\\]?`;
             });
@@ -70,7 +87,7 @@ export class ExpressionFormatter {
         }
 
         // 5. Restore Placeholders
-        Object.keys(placeholders).forEach(key => {
+        Object.keys(placeholders).forEach((key) => {
             str = str.replace(key, placeholders[key]);
         });
 
@@ -97,17 +114,23 @@ export class ExpressionFormatter {
         return `<span class="t1-code-token">${text}</span>`;
     }
 
-    static renderLogicTable(rules: LogicRule[], formatter: (text: string) => string = (t) => ExpressionFormatter.formatCode(t)): string {
+    static renderLogicTable(
+        rules: LogicRule[],
+        formatter: (text: string) => string = (t) => ExpressionFormatter.formatCode(t)
+    ): string {
         if (!rules || rules.length === 0) return '';
         // Note: The caller of renderLogicTable typically binds the colouriseTextHTML with the sets.
 
-        const rows = rules.map(r => `
+        const rows = rules
+            .map(
+                (r) => `
             <div class="t1-logic-row">
                 <div class="t1-logic-outcome">${formatter(r.outcome)}</div>
                 <div class="t1-logic-condition">${formatter(r.condition)}</div>
             </div>
-        `).join('');
-
+        `
+            )
+            .join('');
 
         return `
             <div class="t1-logic-table">
@@ -213,13 +236,17 @@ export class ExpressionFormatter {
         // Try parsing as CASE statement
         const caseRules = this.parseCaseStatement(expr);
         if (caseRules) {
-            return this.renderLogicTable(caseRules, (t) => this.colouriseTextHTML(t, varSet || new Set(), tableSet || new Set(), stepSet || new Set()));
+            return this.renderLogicTable(caseRules, (t) =>
+                this.colouriseTextHTML(t, varSet || new Set(), tableSet || new Set(), stepSet || new Set())
+            );
         }
 
         // Try parsing as IIF statement
         const iifRules = this.parseIifStatement(expr);
         if (iifRules) {
-            return this.renderLogicTable(iifRules, (t) => this.colouriseTextHTML(t, varSet || new Set(), tableSet || new Set(), stepSet || new Set()));
+            return this.renderLogicTable(iifRules, (t) =>
+                this.colouriseTextHTML(t, varSet || new Set(), tableSet || new Set(), stepSet || new Set())
+            );
         }
 
         // Default: just colorize

--- a/src/lib/generators/DashboardGenerator.ts
+++ b/src/lib/generators/DashboardGenerator.ts
@@ -2,7 +2,7 @@ import { db } from '../db';
 import { asNode, type XmlNode, type XmlValue } from '../parsers/types';
 
 export class DashboardGenerator {
-    static async generateHtmlView(id: number, mode: 'business' | 'technical' = 'business'): Promise<string> {
+    static async generateHtmlView(id: number): Promise<string> {
         const dashboard = await db.dashboards.get(id);
         if (!dashboard) throw new Error('Dashboard not found');
 
@@ -201,7 +201,7 @@ export class DashboardGenerator {
         let dashboardParamsHtml = '';
         const dashParams = asNode(dashLayout.Parameters)?.ParameterField;
         const dashParamsList = getList(dashParams);
-        if (dashParamsList.length > 0 && mode === 'technical') {
+        if (dashParamsList.length > 0) {
             const paramRows = dashParamsList.map((p) => ({
                 Col1: escapeHtml(p.FieldName || 'N/A'),
                 Col2: `<code class="bg-gray-100 px-2 py-1 rounded text-xs font-mono">${escapeHtml(p.Value || 'N/A')}</code>`,
@@ -260,9 +260,9 @@ export class DashboardGenerator {
             `;
         }
 
-        // --- Detailed Widgets Section (Technical View Only) ---
+        // --- Detailed Widgets Section ---
         let detailedWidgetsHtml = '';
-        if (visualizations.length > 0 && mode === 'technical') {
+        if (visualizations.length > 0) {
             detailedWidgetsHtml =
                 '<details class="group mb-6"><summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-purple-50 hover:bg-purple-100 transition-colors select-none border-t border-b border-purple-200"><span class="text-xl font-bold text-slate-800 flex items-center gap-3"><span class="text-purple-500 text-lg">📋</span> Widget Details</span></summary><div class="pt-4 pb-2 px-2 space-y-4">';
 

--- a/src/lib/generators/DataModelGenerator.ts
+++ b/src/lib/generators/DataModelGenerator.ts
@@ -3,7 +3,7 @@ import { ExpressionFormatter } from '../formatters/ExpressionFormatter';
 import { asNode, type DataModelParsed, type XmlNode, type XmlValue } from '../parsers/types';
 
 export class DataModelGenerator {
-    static async generateHtmlView(id: number, _viewMode: 'business' | 'technical' = 'business'): Promise<string> {
+    static async generateHtmlView(id: number): Promise<string> {
         const dm = await db.dataModels.get(id);
         if (!dm) throw new Error('Data Model not found');
 

--- a/src/lib/generators/DocxGenerator.ts
+++ b/src/lib/generators/DocxGenerator.ts
@@ -90,7 +90,7 @@ export class DocxGenerator {
         );
 
         try {
-            const imageBase64 = await MermaidGenerator.getFlowChartImage(flowData.executionTree, mode);
+            const imageBase64 = await MermaidGenerator.getFlowChartImage(flowData.executionTree);
             if (imageBase64) {
                 // Convert Base64 (data:image/png;base64,...) to Uint8Array/Buffer
                 const res = await fetch(imageBase64);

--- a/src/lib/generators/DocxGenerator.ts
+++ b/src/lib/generators/DocxGenerator.ts
@@ -41,7 +41,7 @@ export class DocxGenerator {
         const report = await db.reports.get(reportId);
         if (!report) throw new Error('Report not found');
 
-        const flowData = EtlParser.parseSteps(report.rawSteps, mode);
+        const flowData = EtlParser.parseSteps(report.rawSteps);
         const sections: any[] = [];
 
         // 1. Header Information

--- a/src/lib/generators/DocxGenerator.ts
+++ b/src/lib/generators/DocxGenerator.ts
@@ -37,7 +37,7 @@ export class DocxGenerator {
     }
 
     // --- ETL Report Extraction ---
-    static async downloadDocx(reportId: number, mode: 'business' | 'technical' = 'technical') {
+    static async downloadDocx(reportId: number) {
         const report = await db.reports.get(reportId);
         if (!report) throw new Error('Report not found');
 
@@ -187,82 +187,76 @@ export class DocxGenerator {
             sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
         }
 
-        // 3.2 File Locations (Technical mode only)
-        if (mode === 'technical') {
-            const fileLocations = this.extractFileLocations(report.rawFileLocations);
-            if (fileLocations.length > 0) {
-                sections.push(
-                    new Paragraph({
-                        children: [this.createText('File Locations', { bold: true, size: 28 })],
-                        heading: HeadingLevel.HEADING_2,
-                        spacing: { after: 150 },
+        // 3.2 File Locations
+        const fileLocations = this.extractFileLocations(report.rawFileLocations);
+        if (fileLocations.length > 0) {
+            sections.push(
+                new Paragraph({
+                    children: [this.createText('File Locations', { bold: true, size: 28 })],
+                    heading: HeadingLevel.HEADING_2,
+                    spacing: { after: 150 },
+                })
+            );
+
+            const fHeader = new TableRow({
+                children: [
+                    this.createHeaderCell('Location Name'),
+                    this.createHeaderCell('Type'),
+                    this.createHeaderCell('Path'),
+                    this.createHeaderCell('Description'),
+                ],
+            });
+
+            const fRows = fileLocations.map(
+                (loc: any) =>
+                    new TableRow({
+                        children: [
+                            this.createCell(loc.Name, { bold: true }),
+                            this.createCell(loc.LocationType || 'ServerFolder'),
+                            this.createCell(loc.Path || loc.ServerFolder || '-', { font: 'Courier New', size: 18 }),
+                            this.createCell(loc.Description || ''),
+                        ],
                     })
-                );
+            );
 
-                const fHeader = new TableRow({
-                    children: [
-                        this.createHeaderCell('Location Name'),
-                        this.createHeaderCell('Type'),
-                        this.createHeaderCell('Path'),
-                        this.createHeaderCell('Description'),
-                    ],
-                });
+            sections.push(new Table({ width: { size: 100, type: WidthType.PERCENTAGE }, rows: [fHeader, ...fRows] }));
+            sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
+        }
 
-                const fRows = fileLocations.map(
-                    (loc: any) =>
-                        new TableRow({
-                            children: [
-                                this.createCell(loc.Name, { bold: true }),
-                                this.createCell(loc.LocationType || 'ServerFolder'),
-                                this.createCell(loc.Path || loc.ServerFolder || '-', { font: 'Courier New', size: 18 }),
-                                this.createCell(loc.Description || ''),
-                            ],
-                        })
-                );
+        // 3.3 Attachments
+        const attachments = this.extractAttachments(report.rawAttachments);
+        if (attachments.length > 0) {
+            sections.push(
+                new Paragraph({
+                    children: [this.createText('Attachments', { bold: true, size: 28 })],
+                    heading: HeadingLevel.HEADING_2,
+                    spacing: { after: 150 },
+                })
+            );
 
-                sections.push(
-                    new Table({ width: { size: 100, type: WidthType.PERCENTAGE }, rows: [fHeader, ...fRows] })
-                );
-                sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
-            }
+            const aHeader = new TableRow({
+                children: [
+                    this.createHeaderCell('File Name'),
+                    this.createHeaderCell('Description'),
+                    this.createHeaderCell('Size'),
+                ],
+            });
 
-            // 3.3 Attachments (Technical mode only)
-            const attachments = this.extractAttachments(report.rawAttachments);
-            if (attachments.length > 0) {
-                sections.push(
-                    new Paragraph({
-                        children: [this.createText('Attachments', { bold: true, size: 28 })],
-                        heading: HeadingLevel.HEADING_2,
-                        spacing: { after: 150 },
+            const aRows = attachments.map(
+                (att: any) =>
+                    new TableRow({
+                        children: [
+                            this.createCell(att.FileName || att.Name || 'Unknown', { bold: true }),
+                            this.createCell(att.Description || '-'),
+                            this.createCell(
+                                att.FileData ? `${Math.round((att.FileData.length * 0.75) / 1024)} KB` : '-'
+                            ),
+                        ],
                     })
-                );
+            );
 
-                const aHeader = new TableRow({
-                    children: [
-                        this.createHeaderCell('File Name'),
-                        this.createHeaderCell('Description'),
-                        this.createHeaderCell('Size'),
-                    ],
-                });
-
-                const aRows = attachments.map(
-                    (att: any) =>
-                        new TableRow({
-                            children: [
-                                this.createCell(att.FileName || att.Name || 'Unknown', { bold: true }),
-                                this.createCell(att.Description || '-'),
-                                this.createCell(
-                                    att.FileData ? `${Math.round((att.FileData.length * 0.75) / 1024)} KB` : '-'
-                                ),
-                            ],
-                        })
-                );
-
-                sections.push(
-                    new Table({ width: { size: 100, type: WidthType.PERCENTAGE }, rows: [aHeader, ...aRows] })
-                );
-                sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
-            }
+            sections.push(new Table({ width: { size: 100, type: WidthType.PERCENTAGE }, rows: [aHeader, ...aRows] }));
+            sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
         }
 
         // 4. Process Logic (The Steps)
@@ -296,7 +290,7 @@ export class DocxGenerator {
                 })
             );
 
-            if (mode === 'business' && item.SmartDesc) {
+            if (item.SmartDesc) {
                 sections.push(
                     new Paragraph({
                         children: [this.createText('Summary: ' + item.SmartDesc, { italic: true, color: '0055AA' })],
@@ -469,7 +463,7 @@ export class DocxGenerator {
     }
 
     // --- Data Model Extraction ---
-    static async downloadDataModelDocx(id: number, _mode: 'business' | 'technical' = 'technical') {
+    static async downloadDataModelDocx(id: number) {
         const dm = await db.dataModels.get(id);
         if (!dm) throw new Error('Data Model not found');
 
@@ -901,7 +895,7 @@ export class DocxGenerator {
     }
 
     // --- Dashboard DOCX Export ---
-    static async downloadDashboardDocx(id: number, _mode: 'business' | 'technical' = 'business') {
+    static async downloadDashboardDocx(id: number) {
         const dashboard = await db.dashboards.get(id);
         if (!dashboard) throw new Error('Dashboard not found');
 

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -21,7 +21,7 @@ export class EtlGenerator {
         return buildEtlNarrative(sources, targets, flow);
     }
 
-    static async generateHtmlView(reportId: number, mode: 'business' | 'technical' = 'technical'): Promise<string> {
+    static async generateHtmlView(reportId: number): Promise<string> {
         const report = await db.reports.get(reportId);
         if (!report) return '<p class="text-red-500">Report not found</p>';
 
@@ -90,43 +90,7 @@ export class EtlGenerator {
 
         // Build metadata grid - 3 columns across, space between, right-aligned col 3
         const hasNotes = !!metadata.narration;
-        const metaGrid =
-            mode === 'technical'
-                ? `
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6 p-4 bg-white border border-gray-200 rounded-lg text-sm shadow-sm">
-                <div>
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Publisher</span>
-                    <span class="font-medium text-gray-800">${metadata.owner || '-'}</span>
-                </div>
-                <div>
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Version</span>
-                    <span class="font-medium text-gray-800">${metadata.version} <span class="text-gray-400 font-normal">(${statusLabel})</span></span>
-                </div>
-                <div class="text-right">
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">T1 Location</span>
-                    <span class="font-mono text-gray-600 text-xs">${metadata.parentPath || '-'}</span>
-                </div>
-                ${
-                    hasNotes
-                        ? `
-                <div>
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Version Notes</span>
-                    <span class="text-gray-600 text-xs italic">${metadata.narration}</span>
-                </div>
-                `
-                        : ''
-                }
-                <div class="${hasNotes ? '' : 'md:col-span-2'}">
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Published Date</span>
-                    <span class="font-medium text-gray-800">${displayDate}</span>
-                </div>
-                <div class="text-right">
-                    <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Process ID</span>
-                    <span class="font-mono text-gray-500 text-[11px] truncate inline-block" title="${metadata.id}">${metadata.id}</span>
-                </div>
-            </div>
-        `
-                : `
+        const metaGrid = `
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6 p-4 bg-white border border-gray-200 rounded-lg text-sm shadow-sm">
                 <div>
                     <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">Publisher</span>
@@ -175,7 +139,7 @@ export class EtlGenerator {
                 // We'll use the .mermaid class div which is standard.
                 flowChartHtml = `
                     <div class="mt-6 border-t border-slate-200 pt-6">
-                        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-widest mb-4">Process Flow (${mode})</h4>
+                        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-widest mb-4">Process Flow</h4>
                         <div class="mermaid flex justify-center bg-white p-4 rounded-lg border border-slate-100 shadow-inner overflow-x-auto min-h-[150px]">
                             ${mermaidSyntax}
                         </div>
@@ -205,7 +169,7 @@ export class EtlGenerator {
                         <h2 class="text-3xl font-bold text-slate-800 tracking-tight">${metadata.name}</h2>
                         ${metadata.description ? `<p class="text-lg text-slate-600 mt-2 leading-relaxed">${metadata.description}</p>` : ''}
                     </div>
-                    <span class="bg-blue-100 text-blue-800 text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wide border border-blue-200">${mode} VIEW</span>
+                    <span class="bg-blue-100 text-blue-800 text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wide border border-blue-200">TECHNICAL VIEW</span>
                 </div>
                 
                 ${metaGrid}
@@ -220,8 +184,8 @@ export class EtlGenerator {
                 const usedSteps = v.UsedIn && v.UsedIn.length > 0 ? v.UsedIn.join(', ') : '-';
                 return {
                     Col1: v.Name,
-                    Col2: mode === 'technical' ? v.Type || 'Var' : '',
-                    Col3: mode === 'technical' ? v.OriginStep || '-' : '',
+                    Col2: v.Type || 'Var',
+                    Col3: v.OriginStep || '-',
                     Col4: v.InitialValue || '-',
                     Col5: v.Value || 'N/A',
                     Col6: usedSteps,
@@ -238,16 +202,14 @@ export class EtlGenerator {
                     </summary>
                     <div class="pt-4 pb-2 px-2">
                           ${renderTable(
-                              mode === 'technical'
-                                  ? [
-                                        'Variable Name',
-                                        'Type',
-                                        'Origin Step',
-                                        'Initial Value',
-                                        'Value / Expression',
-                                        'Used In',
-                                    ]
-                                  : ['Parameter', 'Setting'],
+                              [
+                                  'Variable Name',
+                                  'Type',
+                                  'Origin Step',
+                                  'Initial Value',
+                                  'Value / Expression',
+                                  'Used In',
+                              ],
                               varRows,
                               varIds
                           )}
@@ -271,9 +233,8 @@ export class EtlGenerator {
                 return seqA - seqB;
             });
 
-            // Build badges for visibility/editability in technical mode
+            // Build badges for visibility/editability
             const buildBadges = (p: any) => {
-                if (mode !== 'technical') return '';
                 const badges: string[] = [];
                 if (p.IsDisplayable === 'false')
                     badges.push(
@@ -290,31 +251,19 @@ export class EtlGenerator {
                 return badges.length > 0 ? ` ${badges.join(' ')}` : '';
             };
 
-            const paramRows =
-                mode === 'technical'
-                    ? sortedParams.map((p: any) => ({
-                          Col1: `${p.Name}${buildBadges(p)}`,
-                          Col2: resolveVarType(p.VariableType),
-                          Col3: p.DefaultValue || '-',
-                          Col4: p.Description || '',
-                          Col5:
-                              p.IsMandatory === 'true'
-                                  ? '<span class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">Required</span>'
-                                  : '<span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">Optional</span>',
-                          Col6: p.Sequence || '-',
-                      }))
-                    : sortedParams.map((p: any) => ({
-                          Col1: p.Name,
-                          Col2: resolveVarType(p.VariableType),
-                          Col3: p.DefaultValue || '-',
-                          Col4: p.Description || '',
-                          Col5: p.IsMandatory === 'true' ? 'Required' : 'Optional',
-                      }));
+            const paramRows = sortedParams.map((p: any) => ({
+                Col1: `${p.Name}${buildBadges(p)}`,
+                Col2: resolveVarType(p.VariableType),
+                Col3: p.DefaultValue || '-',
+                Col4: p.Description || '',
+                Col5:
+                    p.IsMandatory === 'true'
+                        ? '<span class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded">Required</span>'
+                        : '<span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">Optional</span>',
+                Col6: p.Sequence || '-',
+            }));
 
-            const headers =
-                mode === 'technical'
-                    ? ['Parameter Name', 'Type', 'Default', 'Description', 'Required', 'Order']
-                    : ['Parameter Name', 'Type', 'Default Value', 'Description', 'Required'];
+            const headers = ['Parameter Name', 'Type', 'Default', 'Description', 'Required', 'Order'];
 
             const paramRowsWithIds = paramRows.map((p: any) => ({
                 ...p,
@@ -322,7 +271,7 @@ export class EtlGenerator {
             }));
             const paramIds = paramRowsWithIds.map((p: any) => p.id);
             html += `
-                <details ${mode === 'technical' ? 'open' : ''} class="group">
+                <details open class="group">
                     <summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-purple-50 hover:bg-purple-100 transition-colors select-none border-t border-b border-purple-200">
                         <span class="text-xl font-bold text-slate-800 flex items-center gap-3">
                             <span class="text-purple-500 text-lg">⚙</span> Process Parameters
@@ -339,7 +288,7 @@ export class EtlGenerator {
 
         // --- Section: File Locations (from FileLocations.xml) ---
         const fileLocations = this.extractFileLocations(report.rawFileLocations);
-        if (fileLocations.length > 0 && mode === 'technical') {
+        if (fileLocations.length > 0) {
             const locationRows = fileLocations.map((loc: any) => ({
                 Col1: loc.Name,
                 Col2: loc.LocationType || 'ServerFolder',
@@ -367,7 +316,7 @@ export class EtlGenerator {
 
         // --- Section: Attachments (from Attachments.xml) ---
         const attachments = this.extractAttachments(report.rawAttachments);
-        if (attachments.length > 0 && mode === 'technical') {
+        if (attachments.length > 0) {
             // Infer content type from file extension
             const getContentType = (filename: string, contentType?: string): string => {
                 if (contentType) return contentType;
@@ -461,21 +410,8 @@ export class EtlGenerator {
             }
 
             let tableHtml = '';
-            // Allow Query and Transformation tables to render in both modes as requested
-            if (
-                item.TableData &&
-                (mode === 'technical' ||
-                    [
-                        'ImportWarehouseData',
-                        'CreateTable',
-                        'RunDirectQuery',
-                        'RunTableQuery',
-                        'AddColumn',
-                        'UpdateColumn',
-                        'CalculateVariable',
-                        'SetVariable',
-                    ].includes(item.RawType))
-            ) {
+            // Allow all tables to render in technical view
+            if (item.TableData && item.TableData.length) {
                 tableHtml += `<div class="mt-3 w-full">${renderTable(item.Headers, item.TableData)}</div>`;
             }
 
@@ -548,12 +484,12 @@ export class EtlGenerator {
                                      <span class="${iconColor} font-bold font-mono text-lg">${icon}</span>
                                      <span class="font-bold text-slate-800 text-sm">${item.Phase}: ${item.Step}</span>
                                  </div>
-                                 ${isLoop && mode === 'business' ? '<span class="text-xs text-amber-700 font-bold px-2 py-0.5 bg-amber-200 rounded-full border border-amber-300">Loop Sequence</span>' : ''}
+                                 ${''}
                             </summary>
                             <div class="p-4">
                                 <div class="mb-3 text-sm text-gray-700">
                                     ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
-                                    ${mode === 'business' && item.SmartDesc ? `<span class="text-xs text-blue-700 font-medium block mt-1 bg-blue-50 p-1 rounded border border-blue-100">💡 ${item.SmartDesc}</span>` : ''}
+                                    ${item.SmartDesc ? `<span class="text-xs text-blue-700 font-medium block mt-1 bg-blue-50 p-1 rounded border border-blue-100">💡 ${item.SmartDesc}</span>` : ''}
                                 </div>
                                 <div class="pl-2 space-y-4">
                                     ${childrenHtml}
@@ -624,7 +560,7 @@ export class EtlGenerator {
                     <details class="step-collapse">
                         <summary class="cursor-pointer list-none flex items-center justify-between flex-wrap gap-2 mb-1 hover:bg-slate-50 rounded px-1 -mx-1 transition-colors">
                             <span class="font-bold text-slate-800 text-sm">${item.Step}</span>
-                            ${mode === 'technical' ? `<span class="text-xs text-slate-400 font-mono">(${item.RawType})</span>` : ''}
+                            <span class="text-xs text-slate-400 font-mono">(${item.RawType})</span>
                             ${filenameIcon ? `<span class="${filenameClass}">${filenameIcon} </span>` : ''}
                         </summary>
 
@@ -634,14 +570,14 @@ export class EtlGenerator {
                                     ? `
                             <div class="text-sm text-gray-600 mb-1">
                                 ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
-                                ${mode === 'business' && item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${item.SmartDesc}</span>` : ''}
+                                ${item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${item.SmartDesc}</span>` : ''}
                             </div>`
                                     : ''
                             }
 
                             ${item.Description ? `<div class="text-xs text-slate-500 italic mb-2">Note: ${ExpressionFormatter.colouriseTextHTML(item.Description, variableSet, tableSet)}</div>` : ''}
 
-                            ${mode === 'technical' ? this.renderStepTechnicalDetails(item) : ''}
+                            ${this.renderStepTechnicalDetails(item)}
                             ${notesHtml}
                             ${detailsHtml}
                             ${tableHtml}

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -178,7 +178,7 @@ export class EtlGenerator {
                 ${summaryHtml}
         `;
 
-        // --- Section: Variables (Show in both modes, as Parameters are relevant) ---
+        // --- Section: Variables ---
         if (variables.length > 0) {
             const varRows = variables.map((v: any) => {
                 const usedSteps = v.UsedIn && v.UsedIn.length > 0 ? v.UsedIn.join(', ') : '-';
@@ -410,7 +410,7 @@ export class EtlGenerator {
             }
 
             let tableHtml = '';
-            // Allow all tables to render in technical view
+            // Allow all tables to render
             if (item.TableData && item.TableData.length) {
                 tableHtml += `<div class="mt-3 w-full">${renderTable(item.Headers, item.TableData)}</div>`;
             }
@@ -484,7 +484,7 @@ export class EtlGenerator {
                                      <span class="${iconColor} font-bold font-mono text-lg">${icon}</span>
                                      <span class="font-bold text-slate-800 text-sm">${item.Phase}: ${item.Step}</span>
                                  </div>
-                                 ${''}
+
                             </summary>
                             <div class="p-4">
                                 <div class="mb-3 text-sm text-gray-700">
@@ -593,7 +593,7 @@ export class EtlGenerator {
     }
 
     // Legacy support if needed, but ideally usage should move to EtlParser
-    static parseSteps(json: any, _mode?: 'business' | 'technical') {
+    static parseSteps(json: any) {
         return EtlParser.parseSteps(json); // mode dropped; only technical view remains
     }
 

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -167,7 +167,7 @@ export class EtlGenerator {
         let flowChartHtml = '';
         try {
             // Get simplified or detailed syntax
-            const mermaidSyntax = MermaidGenerator.getRawSyntax(flowData.executionTree, mode);
+            const mermaidSyntax = MermaidGenerator.getRawSyntax(flowData.executionTree);
             if (mermaidSyntax) {
                 // Initialize Mermaid (Client-Side)
                 // We inject a small script to render this specific block if needed, or rely on global init.

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -21,11 +21,11 @@ export class EtlGenerator {
         return buildEtlNarrative(sources, targets, flow);
     }
 
-    static async generateHtmlView(reportId: number, mode: 'business' | 'technical'): Promise<string> {
+    static async generateHtmlView(reportId: number, mode: 'business' | 'technical' = 'technical'): Promise<string> {
         const report = await db.reports.get(reportId);
         if (!report) return '<p class="text-red-500">Report not found</p>';
 
-        const flowData = EtlParser.parseSteps(report.rawSteps, mode);
+        const flowData = EtlParser.parseSteps(report.rawSteps);
         const metadata = report.metadata;
         const { executionTree, variables, variableSet, tableSet, stepSet } = flowData;
 
@@ -657,8 +657,8 @@ export class EtlGenerator {
     }
 
     // Legacy support if needed, but ideally usage should move to EtlParser
-    static parseSteps(json: any, mode: 'business' | 'technical') {
-        return EtlParser.parseSteps(json, mode);
+    static parseSteps(json: any, _mode?: 'business' | 'technical') {
+        return EtlParser.parseSteps(json); // mode dropped; only technical view remains
     }
 
     // --- Helper: Extract Process Parameters from Variables.xml ---

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -489,7 +489,7 @@ export class EtlGenerator {
                             <div class="p-4">
                                 <div class="mb-3 text-sm text-gray-700">
                                     ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
-                                    ${item.SmartDesc ? `<span class="text-xs text-blue-700 font-medium block mt-1 bg-blue-50 p-1 rounded border border-blue-100">💡 ${item.SmartDesc}</span>` : ''}
+                                    ${item.SmartDesc ? `<span class="text-xs text-blue-700 font-medium block mt-1 bg-blue-50 p-1 rounded border border-blue-100">💡 ${ExpressionFormatter.escapeHtml(item.SmartDesc)}</span>` : ''}
                                 </div>
                                 <div class="pl-2 space-y-4">
                                     ${childrenHtml}
@@ -570,7 +570,7 @@ export class EtlGenerator {
                                     ? `
                             <div class="text-sm text-gray-600 mb-1">
                                 ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
-                                ${item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${item.SmartDesc}</span>` : ''}
+                                ${item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${ExpressionFormatter.escapeHtml(item.SmartDesc)}</span>` : ''}
                             </div>`
                                     : ''
                             }

--- a/src/lib/generators/MermaidGenerator.ts
+++ b/src/lib/generators/MermaidGenerator.ts
@@ -46,7 +46,6 @@ export class MermaidGenerator {
      * Generates the mermaid syntax for the given flow.
      */
     static generateMermaidSyntax(flow: any[]): string {
-        const isTech = true;
         let graph = 'flowchart TD\n';
 
         // Define classes for styling
@@ -84,7 +83,7 @@ export class MermaidGenerator {
 
             items.forEach((item) => {
                 // --- Group Handling (Subgraph) ---
-                if (item.RawType === 'Group' || (isTech && item.RawType === 'Loop')) {
+                if (item.RawType === 'Group' || item.RawType === 'Loop') {
                     const groupId = getSafeId(item.Step);
                     // Use a subgraph for visual grouping
                     steps.push(`    subgraph ${groupId}_sg ["${item.RawType}: ${item.Step}"]`);

--- a/src/lib/generators/MermaidGenerator.ts
+++ b/src/lib/generators/MermaidGenerator.ts
@@ -45,8 +45,8 @@ export class MermaidGenerator {
     /**
      * Generates the mermaid syntax for the given flow.
      */
-    static generateMermaidSyntax(flow: any[], mode: 'business' | 'technical'): string {
-        const isTech = mode === 'technical';
+    static generateMermaidSyntax(flow: any[]): string {
+        const isTech = true;
         let graph = 'flowchart TD\n';
 
         // Define classes for styling
@@ -168,28 +168,10 @@ export class MermaidGenerator {
                     shape = '[(';
                     shapeEnd = ')]';
                     className = 'process';
-                    if (!isTech) label = '⚙️' + label.trim(); // Simplified in business
                 } else if (['CalculateVariable', 'SetVariable'].includes(item.RawType)) {
                     shape = '[(';
                     shapeEnd = ')]';
                     className = 'process';
-                    if (!isTech) label = '🔢' + label.trim(); // Simplified in business
-                }
-
-                // Business Mode Simplification: Make calc steps smaller/simplified but still visible
-                if (
-                    !isTech &&
-                    (item.RawType === 'AddColumn' || item.RawType === 'CalculateVariable') &&
-                    !item.Description
-                ) {
-                    // Don't skip - just simplify label
-                    label = label.length > 30 ? label.substring(0, 30) + '...' : label;
-                    // Use minimal node style
-                    shape = '[(';
-                    shapeEnd = ')]';
-                    className = 'process';
-                    // Skip rendering this node in business mode
-                    return;
                 }
 
                 steps.push(`    ${id}${shape}"${label}"${shapeEnd}:::${className}`);
@@ -249,14 +231,10 @@ export class MermaidGenerator {
     /**
      * Renders the flow chart to an SVG string using Mermaid.
      */
-    static async renderToSvg(
-        flow: any[],
-        mode: 'business' | 'technical',
-        id: string = 'mermaid-chart'
-    ): Promise<string> {
+    static async renderToSvg(flow: any[], id: string = 'mermaid-chart'): Promise<string> {
         await this.initialize();
         const mermaid = await this.load();
-        const syntax = this.generateMermaidSyntax(flow, mode);
+        const syntax = this.generateMermaidSyntax(flow);
         try {
             const { svg } = await mermaid.render(id, syntax);
             return svg;
@@ -269,15 +247,15 @@ export class MermaidGenerator {
     /**
      * Renders simple syntax for direct embedding (if using mermaid.contentLoaded)
      */
-    static getRawSyntax(flow: any[], mode: 'business' | 'technical'): string {
-        return this.generateMermaidSyntax(flow, mode);
+    static getRawSyntax(flow: any[]): string {
+        return this.generateMermaidSyntax(flow);
     }
 
     /**
      * Generates a base64 PNG image for DOCX embedding.
      */
-    static async getFlowChartImage(flow: any[], mode: 'business' | 'technical'): Promise<string> {
-        const svg = await this.renderToSvg(flow, mode, 'mermaid-hidden-' + Date.now());
+    static async getFlowChartImage(flow: any[]): Promise<string> {
+        const svg = await this.renderToSvg(flow, 'mermaid-hidden-' + Date.now());
 
         // 1. Create a dummy container to parse SVG
         const parser = new DOMParser();

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -204,7 +204,7 @@ export class EtlParser {
      * Main Parsing Method
      * Returns a structured execution tree with metadata, variable usage, and logic rules pre-calculated.
      */
-    static parseSteps(json: XmlValue, mode: 'business' | 'technical' = 'technical') {
+    static parseSteps(json: XmlValue) {
         const stepsRaw = this.getListSafe(asNode(json)?.ArrayOfStep, 'Step') as RawStep[];
         const stepMap = new Map<number, RawStep>();
         const rootSteps: RawStep[] = [];
@@ -397,15 +397,6 @@ export class EtlParser {
                 }
             }
 
-            // Business Filtering
-            if (mode === 'business') {
-                const ignore = ['PurgeTable', 'CreateTable', 'DeleteTable'];
-                if (!isActive || ignore.includes(stepType)) {
-                    if (stepType !== 'Loop' && stepType !== 'Group' && stepType !== 'Decision' && stepType !== 'Branch')
-                        return null;
-                }
-            }
-
             const description = this.getTextSafe(step.Description || step.Narration || step.Comments);
 
             // Build Context String (Simplified for Parser, Formatter can enhance)
@@ -416,100 +407,69 @@ export class EtlParser {
             const target = this.getTextSafe(storage.OutputTableName || storage.TableName || 'target');
 
             // Replicating basic context string logic (without HTML formatting)
-            if (mode === 'business') {
-                switch (stepType) {
-                    case 'RunDirectQuery':
-                        contextText = `${stepNameDisplay} (from ${table})`;
-                        break;
-                    case 'RunTableQuery':
-                        contextText = stepNameDisplay;
-                        break;
-                    case 'AddColumn':
-                        contextText = `${stepNameDisplay} (in ${table})`;
-                        break;
-                    case 'UpdateColumn':
-                        contextText = `${stepNameDisplay} (in ${table})`;
-                        break;
-                    case 'ImportWarehouseData':
-                        contextText = stepNameDisplay;
-                        break;
-                    case 'DeleteWarehouseData':
-                        contextText = `${stepNameDisplay} (from ${target})`;
-                        break;
-                    case 'JoinTable':
-                        contextText = `${stepNameDisplay} (with ${this.getTextSafe(storage.JoinTable2)})`;
-                        break;
-                    case 'Loop':
-                        contextText = `${stepNameDisplay} (iterate ${this.getTextSafe(storage.InputVariable)})`;
-                        break;
-                    default:
-                        contextText = stepNameDisplay;
+            switch (stepType) {
+                case 'RunDirectQuery':
+                    contextText = `${stepNameDisplay}: pull ${table}`;
+                    break;
+                case 'RunTableQuery':
+                    contextText = `${stepNameDisplay}: read ${table}`;
+                    break;
+                case 'RunDatasourceQuery':
+                case 'RunSimpleQuery':
+                    contextText = `${stepNameDisplay}: ${this.getTextSafe(storage.DatasourceName || 'Datasource')} ➔ ${target}`;
+                    break;
+                case 'AddColumn':
+                    contextText = `${stepNameDisplay}: calculate in ${table}`;
+                    break;
+                case 'UpdateColumn':
+                    contextText = `${stepNameDisplay}: update values in ${table}`;
+                    break;
+                case 'ImportWarehouseData':
+                    contextText = `${stepNameDisplay}: publish to ${target}`;
+                    break;
+                case 'DeleteWarehouseData':
+                    contextText = `${stepNameDisplay}: remove from ${target}`;
+                    break;
+                case 'JoinTable':
+                    contextText = `${stepNameDisplay}: combine with ${this.getTextSafe(storage.JoinTable2)}`;
+                    break;
+                case 'Loop':
+                    contextText = `${stepNameDisplay}: iterate ${this.getTextSafe(storage.InputVariable)}`;
+                    break;
+                // New Support
+                case 'ExportToExcel': {
+                    const filename = this.getTextSafe(storage.ExportMemoryTableName || table);
+                    const path = this.getTextSafe(storage.FileName || '');
+                    const pathPart = path ? ` (${path})` : '';
+                    contextText = `${stepNameDisplay}: export ${filename} to Excel${pathPart}`;
+                    break;
                 }
-            } else {
-                switch (stepType) {
-                    case 'RunDirectQuery':
-                        contextText = `${stepNameDisplay}: pull ${table}`;
-                        break;
-                    case 'RunTableQuery':
-                        contextText = `${stepNameDisplay}: read ${table}`;
-                        break;
-                    case 'RunDatasourceQuery':
-                    case 'RunSimpleQuery':
-                        contextText = `${stepNameDisplay}: ${this.getTextSafe(storage.DatasourceName || 'Datasource')} ➔ ${target}`;
-                        break;
-                    case 'AddColumn':
-                        contextText = `${stepNameDisplay}: calculate in ${table}`;
-                        break;
-                    case 'UpdateColumn':
-                        contextText = `${stepNameDisplay}: update values in ${table}`;
-                        break;
-                    case 'ImportWarehouseData':
-                        contextText = `${stepNameDisplay}: publish to ${target}`;
-                        break;
-                    case 'DeleteWarehouseData':
-                        contextText = `${stepNameDisplay}: remove from ${target}`;
-                        break;
-                    case 'JoinTable':
-                        contextText = `${stepNameDisplay}: combine with ${this.getTextSafe(storage.JoinTable2)}`;
-                        break;
-                    case 'Loop':
-                        contextText = `${stepNameDisplay}: iterate ${this.getTextSafe(storage.InputVariable)}`;
-                        break;
-                    // New Support
-                    case 'ExportToExcel': {
-                        const filename = this.getTextSafe(storage.ExportMemoryTableName || table);
-                        const path = this.getTextSafe(storage.FileName || '');
-                        const pathPart = path ? ` (${path})` : '';
-                        contextText = `${stepNameDisplay}: export ${filename} to Excel${pathPart}`;
-                        break;
-                    }
-                    case 'SendEmail':
-                        contextText = `${stepNameDisplay}: send to ${this.getTextSafe(storage.SendTo)}`;
-                        break;
-                    case 'LoadTextFile': {
-                        const filename = this.getTextSafe(storage.FileName || '');
-                        const path = this.getTextSafe(storage.FileLocation || storage.Path || '');
-                        const pathPart = path ? ` (${path})` : '';
-                        contextText = `${stepNameDisplay}: load ${pathPart ? `${filename}${pathPart}` : filename} into ${this.getTextSafe(storage.MemoryTableName || table)}`;
-                        break;
-                    }
-                    case 'SaveText':
-                    case 'SaveTextfile': {
-                        const filename = this.getTextSafe(storage.FileName || 'Text File');
-                        const path = this.getTextSafe(storage.FileLocation || storage.Path || '');
-                        const pathPart = path ? ` (${path})` : '';
-                        contextText = `Save ${filename} to ${this.getTextSafe(storage.MemoryTableName || table)}${pathPart}`;
-                        break;
-                    }
-                    case 'Decision':
-                        contextText = `Decision on ${this.getTextSafe(storage.InputTableName || 'Table')}`;
-                        break;
-                    case 'Branch':
-                        contextText = `If ${this.getTextSafe(storage.Expression)}`;
-                        break;
-                    default:
-                        contextText = stepType;
+                case 'SendEmail':
+                    contextText = `${stepNameDisplay}: send to ${this.getTextSafe(storage.SendTo)}`;
+                    break;
+                case 'LoadTextFile': {
+                    const filename = this.getTextSafe(storage.FileName || '');
+                    const path = this.getTextSafe(storage.FileLocation || storage.Path || '');
+                    const pathPart = path ? ` (${path})` : '';
+                    contextText = `${stepNameDisplay}: load ${pathPart ? `${filename}${pathPart}` : filename} into ${this.getTextSafe(storage.MemoryTableName || table)}`;
+                    break;
                 }
+                case 'SaveText':
+                case 'SaveTextfile': {
+                    const filename = this.getTextSafe(storage.FileName || 'Text File');
+                    const path = this.getTextSafe(storage.FileLocation || storage.Path || '');
+                    const pathPart = path ? ` (${path})` : '';
+                    contextText = `Save ${filename} to ${this.getTextSafe(storage.MemoryTableName || table)}${pathPart}`;
+                    break;
+                }
+                case 'Decision':
+                    contextText = `Decision on ${this.getTextSafe(storage.InputTableName || 'Table')}`;
+                    break;
+                case 'Branch':
+                    contextText = `If ${this.getTextSafe(storage.Expression)}`;
+                    break;
+                default:
+                    contextText = stepType;
             }
 
             // Collect Inputs and Outputs

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,6 @@ registerServiceWorker();
 let currentView: 'dashboard' | 'detail' = 'dashboard';
 let currentReportId: number | null = null;
 let currentType: 'report' | 'datamodel' | 'dashboard' = 'report';
-let currentMode: 'business' | 'technical' = 'business';
 
 // --- HTML Template Helpers ---
 function header() {
@@ -186,10 +185,6 @@ async function render() {
                         Back to Library
                     </button>
 
-                    <div class="bg-white p-1 rounded-xl shadow-sm border border-gray-200 flex text-xs font-medium self-center">
-                        <button class="mode-btn ${currentMode === 'business' ? 'active' : ''} px-6 py-2 rounded-lg transition-all duration-200 text-gray-500 hover:text-gray-900" onclick="window.setMode('business')">Business View</button>
-                        <button class="mode-btn ${currentMode === 'technical' ? 'active' : ''} px-6 py-2 rounded-lg transition-all duration-200 text-gray-500 hover:text-gray-900" onclick="window.setMode('technical')">Technical View</button>
-                    </div>
                     <button onclick="window.exportDocx()" class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-bold transition-all shadow-sm flex items-center justify-center">
                          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
                          Export
@@ -313,7 +308,6 @@ function setupDragAndDrop() {
 declare global {
     interface Window {
         navigateTo: (view: 'dashboard' | 'detail', id?: number, type?: 'report' | 'datamodel' | 'dashboard') => void;
-        setMode: (mode: 'business' | 'technical') => void;
         exportDocx: () => void;
         deleteEntity: (id: number, type: 'report' | 'datamodel' | 'dashboard') => void;
         editStepNote: (reportId: string, stepId: string) => void;
@@ -329,11 +323,6 @@ window.navigateTo = (view, id, type) => {
     currentView = view;
     if (id) currentReportId = id;
     if (type) currentType = type;
-    render();
-};
-
-window.setMode = (mode) => {
-    currentMode = mode;
     render();
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -341,11 +341,11 @@ window.exportDocx = async () => {
     if (currentReportId) {
         try {
             if (currentType === 'report') {
-                await DocxGenerator.downloadDocx(currentReportId, currentMode);
+                await DocxGenerator.downloadDocx(currentReportId);
             } else if (currentType === 'datamodel') {
-                await DocxGenerator.downloadDataModelDocx(currentReportId, currentMode);
+                await DocxGenerator.downloadDataModelDocx(currentReportId);
             } else if (currentType === 'dashboard') {
-                await DocxGenerator.downloadDashboardDocx(currentReportId, currentMode);
+                await DocxGenerator.downloadDashboardDocx(currentReportId);
             }
         } catch (e) {
             console.error(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -217,7 +217,7 @@ async function render() {
             if (currentType === 'report') {
                 html = await EtlGenerator.generateHtmlView(currentReportId);
             } else if (currentType === 'datamodel') {
-                html = await DataModelGenerator.generateHtmlView(currentReportId, currentMode);
+                html = await DataModelGenerator.generateHtmlView(currentReportId);
             } else if (currentType === 'dashboard') {
                 html = await DashboardGenerator.generateHtmlView(currentReportId, currentMode);
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -219,7 +219,7 @@ async function render() {
             } else if (currentType === 'datamodel') {
                 html = await DataModelGenerator.generateHtmlView(currentReportId);
             } else if (currentType === 'dashboard') {
-                html = await DashboardGenerator.generateHtmlView(currentReportId, currentMode);
+                html = await DashboardGenerator.generateHtmlView(currentReportId);
             }
             const container = document.getElementById('detailContainer');
             if (container) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ function dashboardLayout(items: any[]) {
             let summaryText = r.metadata.description;
             if (r.type === 'report') {
                 try {
-                    const flowData = EtlParser.parseSteps(r.rawSteps, 'business');
+                    const flowData = EtlParser.parseSteps(r.rawSteps);
                     summaryText = EtlGenerator.generateSummary(flowData.executionFlow);
                 } catch (e) {
                     console.error('Failed dashboard summary', e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,7 +215,7 @@ async function render() {
         try {
             let html = '';
             if (currentType === 'report') {
-                html = await EtlGenerator.generateHtmlView(currentReportId, currentMode);
+                html = await EtlGenerator.generateHtmlView(currentReportId);
             } else if (currentType === 'datamodel') {
                 html = await DataModelGenerator.generateHtmlView(currentReportId, currentMode);
             } else if (currentType === 'dashboard') {

--- a/src/style.css
+++ b/src/style.css
@@ -14,13 +14,6 @@ body {
   flex-direction: column;
 }
 
-/* UI Components */
-.mode-btn.active {
-  background-color: #2563eb;
-  color: white;
-  border-color: #2563eb;
-}
-
 /* Document Styling */
 .doc-paper {
   background: white;

--- a/tests/EtlGenerator.test.ts
+++ b/tests/EtlGenerator.test.ts
@@ -27,7 +27,7 @@ describe('EtlGenerator', () => {
 
     it('returns error html if report not found', async () => {
         vi.mocked(db.reports.get).mockResolvedValue(undefined);
-        const html = await EtlGenerator.generateHtmlView(999, 'technical');
+        const html = await EtlGenerator.generateHtmlView(999);
         expect(html).toContain('Report not found');
     });
 
@@ -52,7 +52,7 @@ describe('EtlGenerator', () => {
         };
         vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
 
-        const html = await EtlGenerator.generateHtmlView(1, 'technical');
+        const html = await EtlGenerator.generateHtmlView(1);
 
         expect(html).toContain('extracts data from <span class="t1-table-badge" data-type="table">𝄜 SRC</span>');
         expect(html).toContain('publishes results to <strong>the DEST</strong>');
@@ -88,7 +88,7 @@ describe('EtlGenerator', () => {
         };
         vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
 
-        const html = await EtlGenerator.generateHtmlView(1, 'technical');
+        const html = await EtlGenerator.generateHtmlView(1);
 
         expect(html).toContain('My Group');
         expect(html).toContain('Child Step');
@@ -118,7 +118,7 @@ describe('EtlGenerator', () => {
         };
         vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
 
-        const html = await EtlGenerator.generateHtmlView(1, 'technical');
+        const html = await EtlGenerator.generateHtmlView(1);
         
         expect(html).toContain('This is a note');
         expect(html).toContain('step-notes-container');
@@ -142,7 +142,7 @@ describe('EtlGenerator', () => {
         };
         vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
 
-        const html = await EtlGenerator.generateHtmlView(1, 'technical');
+        const html = await EtlGenerator.generateHtmlView(1);
         expect(html).toContain('Var1');
         expect(html).toContain('100');
         expect(html).toContain('Variables & Parameters');

--- a/tests/EtlParser.KitchenSink.test.ts
+++ b/tests/EtlParser.KitchenSink.test.ts
@@ -39,7 +39,7 @@ describe('EtlParser (Kitchen Sink)', () => {
             }
         };
 
-        const result = EtlParser.parseSteps(mockSteps, 'technical');
+        const result = EtlParser.parseSteps(mockSteps);
 
         expect(result.executionTree).toHaveLength(7);
         // We just want to ensure it runs without error and covers the branches.

--- a/tests/EtlParser.test.ts
+++ b/tests/EtlParser.test.ts
@@ -74,7 +74,7 @@ describe('EtlParser', () => {
                 }
             };
 
-            const result = EtlParser.parseSteps(mockSteps, 'technical');
+            const result = EtlParser.parseSteps(mockSteps);
 
             expect(result.executionTree).toHaveLength(1);
             const step = result.executionTree[0];
@@ -105,7 +105,7 @@ describe('EtlParser', () => {
                 }
             };
 
-            const result = EtlParser.parseSteps(mockSteps, 'technical');
+            const result = EtlParser.parseSteps(mockSteps);
 
             expect(result.executionTree).toHaveLength(1); // Only root
             const root = result.executionTree[0];
@@ -123,7 +123,7 @@ describe('EtlParser', () => {
                     ]
                 }
             };
-            const result = EtlParser.parseSteps(mockSteps, 'technical');
+            const result = EtlParser.parseSteps(mockSteps);
             expect(result.executionTree).toHaveLength(1);
             expect(result.executionTree[0].Step).toBe('Parent');
             expect(result.executionTree[0].children[0].Step).toBe('Child');
@@ -149,7 +149,7 @@ describe('EtlParser', () => {
                 }
             };
 
-            const result = EtlParser.parseSteps(mockSteps, 'technical');
+            const result = EtlParser.parseSteps(mockSteps);
             expect(result.variableSet.has('myVar')).toBe(true);
             const variable = result.variables.find(v => v.Name === 'myVar');
             expect(variable?.Value).toBe('123');
@@ -163,7 +163,7 @@ describe('EtlParser', () => {
                     ]
                 }
             };
-            const result = EtlParser.parseSteps(mockSteps, 'technical');
+            const result = EtlParser.parseSteps(mockSteps);
             expect(result.executionTree).toHaveLength(1);
             expect(result.executionTree[0].Step).toBe("Orphan");
         });

--- a/tests/ExpressionFormatter.test.ts
+++ b/tests/ExpressionFormatter.test.ts
@@ -4,6 +4,20 @@ import { ExpressionFormatter } from '../src/lib/formatters/ExpressionFormatter';
 
 describe('ExpressionFormatter', () => {
 
+    describe('escapeHtml', () => {
+        it('escapes HTML special characters', () => {
+            const input = `<script>alert("x")</script> & 'quote'`;
+            const output = ExpressionFormatter.escapeHtml(input);
+            expect(output).toBe('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; &#039;quote&#039;');
+            expect(output).not.toContain('<script>');
+        });
+
+        it('returns empty string for null/undefined', () => {
+            expect(ExpressionFormatter.escapeHtml(null)).toBe('');
+            expect(ExpressionFormatter.escapeHtml(undefined)).toBe('');
+        });
+    });
+
     describe('colouriseTextHTML', () => {
         it('should wrap known variables in var-badges', () => {
             const varSet = new Set(['MyVar', 'OtherVar']);

--- a/tests/MermaidGenerator.test.ts
+++ b/tests/MermaidGenerator.test.ts
@@ -27,7 +27,7 @@ describe('MermaidGenerator', () => {
     ];
 
     it('generates basic syntax in technical mode', () => {
-        const syntax = MermaidGenerator.generateMermaidSyntax(mockFlow, 'technical');
+        const syntax = MermaidGenerator.generateMermaidSyntax(mockFlow);
          // Basic Checks
         expect(syntax).toContain('flowchart TD');
         expect(syntax).toContain('N0[("📥 Data")]:::source');
@@ -38,29 +38,6 @@ describe('MermaidGenerator', () => {
 
         // Colors
         expect(syntax).toContain('classDef source');
-    });
-
-    it('filters correctly in business mode', () => {
-        const busFlow = [
-            ...mockFlow,
-            { // Should be ignored
-                Step: 'StepIgnore',
-                Context: 'Hidden Calc',
-                RawType: 'AddColumn',
-                children: []
-            }
-        ];
-
-        const syntax = MermaidGenerator.generateMermaidSyntax(busFlow, 'business');
-        expect(syntax).toContain('N0');
-        expect(syntax).toContain('N1'); // Has description, so kept
-        expect(syntax).toContain('N2');
-
-        // StepIgnore should NOT be in the syntax if filtered correctly
-        // N3 would be the index if it was included. 
-        // Logic check: The generator relies on `traverse` pushing to `steps`.
-        // If skipped, no node is created.
-        expect(syntax).not.toContain('Hidden Calc');
     });
 
 
@@ -80,7 +57,7 @@ describe('MermaidGenerator', () => {
             ]
         }];
 
-        const syntax = MermaidGenerator.generateMermaidSyntax(loopFlow, 'technical');
+        const syntax = MermaidGenerator.generateMermaidSyntax(loopFlow);
         expect(syntax).toContain('subgraph N0_sg');
         expect(syntax).toContain('N1[("Do Work")]');
         expect(syntax).toContain('end');
@@ -95,7 +72,7 @@ describe('MermaidGenerator', () => {
             children: []
         }];
 
-        const syntax = MermaidGenerator.generateMermaidSyntax(groupFlow, 'business');
+        const syntax = MermaidGenerator.generateMermaidSyntax(groupFlow);
         // Expect subgraph for Groups now
         expect(syntax).toContain('subgraph N0_sg');
         expect(syntax).toContain('style N0_sg fill:#ffe4e6');
@@ -124,7 +101,7 @@ describe('MermaidGenerator', () => {
             ]
         }];
 
-        const syntax = MermaidGenerator.generateMermaidSyntax(decisionFlow, 'technical');
+        const syntax = MermaidGenerator.generateMermaidSyntax(decisionFlow);
         // Relaxed Checks
         expect(syntax).toContain('Check Value');
         expect(syntax).toContain('Yes');


### PR DESCRIPTION
## Summary

Removes the Business/Technical view toggle app-wide, leaving a single unified **Technical** view that retains the SmartDesc AI-insight badges. The toggle previously spanned ETL, Data Model, Dashboard, Mermaid, and DOCX generation plus the parser — 59 references across 8 source files.

**Survivor decisions:**
- Survivor view = Technical; previously technical-only sections (File Locations, Attachments, Dashboard params + detailed widgets, RawType labels, `renderStepTechnicalDetails`) now **always** render.
- **SmartDesc kept** — badges show whenever `item.SmartDesc` is truthy (HTML + DOCX), no longer gated to the removed business mode.

## What changed

**Code (`src/`):**
- `EtlParser.parseSteps` — dropped `mode` param; removed business step-filtering + business `contextText` branch.
- `EtlGenerator` / `DataModelGenerator` / `DashboardGenerator` / `DocxGenerator` — dropped `mode`/`viewMode` params; hard-selected technical paths; SmartDesc unconditional.
- `MermaidGenerator` — dropped `mode` from all 4 methods; removed business label-simplification + node-skip branches.
- `main.ts` — removed `currentMode` state, the toggle UI buttons, and `window.setMode`.
- `style.css` — removed dead `.mode-btn` rules.

**Docs:** README, ETL_STRUCTURE, DATAMODEL_STRUCTURE (collapsed Business/Technical columns → single Exposed), API_REFERENCE, ARCHITECTURE, GENERATORS, FILE_FORMATS (dropped stale mode references). Implementation plan added under `docs/superpowers/plans/`.

## Test Plan

- [x] `pnpm test` — 55/55 pass (one obsolete business-mode Mermaid test removed)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — succeeds (SW generated)
- [ ] Manual smoke: upload `.t1etlp` / `.t1dm` / `.t1db`, confirm no toggle, full technical detail + 💡 SmartDesc badges + File Locations/Attachments render, DOCX export works

## Reviewer notes

- `EtlSummary.ts` `performs business calculations` is example prose, intentionally untouched.
- Pre-existing literal-backslash artifacts (`<\p>`, `\ ---`) in EtlGenerator/DataModelGenerator left as-is — out of scope.
- Follow-up flagged (not in this PR): `FILE_FORMATS.md` still lists Variables/FileLocations/Attachments XML as "NOT PARSED" — pre-existing doc drift, needs separate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)