### PR TITLE
feat(etl): replace step timeline with linked flow diagram

### DIFF
--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -374,14 +374,18 @@ export class EtlGenerator {
             const n = name.toLowerCase();
             if (n.endsWith('.csv') || n.endsWith('.txt') || n.endsWith('.xlsx') || n.endsWith('.xls'))
                 return { cls: 'flow-tok-file', glyph: '📄' };
-            // Recordsets / memory tables / variables flowing between steps
-            if (/^rs|^mem|^v[A-Z]|recordset|memory/i.test(name)) return { cls: 'flow-tok-rs', glyph: '⬡' };
+            // Recordsets / memory tables / variables flowing between steps.
+            // The camelCase variable prefix (vName) is case-SENSITIVE — a lowercase
+            // `/i` match here wrongly tagged tables like `vendors` as recordsets.
+            if (/^rs|^mem|recordset|memory/i.test(name) || /^[vV][A-Z]/.test(name))
+                return { cls: 'flow-tok-rs', glyph: '⬡' };
             return { cls: asOutput ? 'flow-tok-out' : 'flow-tok-table', glyph: '▦' };
         };
 
         const tokenChip = (rawName: string, role: 'producer' | 'consumer', asOutput: boolean): string => {
             const name = (rawName || '').trim();
-            if (!name || name === 'DATA' || name === 'dataset' || name === 'target') return '';
+            const placeholder = name.toUpperCase();
+            if (!name || placeholder === 'DATA' || placeholder === 'DATASET' || placeholder === 'TARGET') return '';
             const key = name.toUpperCase().replace(/\s+/g, ' ');
             const { cls, glyph } = tokenKind(name, asOutput);
             return `<span class="flow-tok ${cls}" data-token="${ExpressionFormatter.escapeHtml(key)}" data-role="${role}"><span class="opacity-60">${glyph}</span> ${ExpressionFormatter.escapeHtml(name)}</span>`;
@@ -662,9 +666,12 @@ export class EtlGenerator {
         html += renderFlow(executionTree);
 
         // Target pills at the bottom of the spine (always shown; placeholder if none).
+        // extractSourcesAndTargets decorates file targets with " (Excel)" / " (Text
+        // file)" suffixes; strip them so the pill's token key matches the bare
+        // filename used in step Outputs, keeping hover-to-trace lineage intact.
         const targetPills = targets.length
             ? targets
-                  .map((t) => tokenChip(t, 'consumer', true))
+                  .map((t) => tokenChip(t.replace(/\s*\((?:Excel|Text file)\)$/i, ''), 'consumer', true))
                   .filter(Boolean)
                   .join(' ')
             : `<span class="flow-tok flow-tok-empty">none · no table output</span>`;

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -365,10 +365,68 @@ export class EtlGenerator {
             `;
         }
 
-        // --- Section: Process Logic ---
-        // Heading removed per request ("Process Logic" hidden, content visible)
+        // --- Section: Process Logic (Linked Flow Diagram) ---
+
+        // Classify a token name so chips of the same kind look identical wherever
+        // they appear. Tables/warehouse = blue/green, recordset+variable = purple,
+        // file = green-file, analyser = purple-diamond. Normalised name is the link key.
+        const tokenKind = (name: string, asOutput: boolean): { cls: string; glyph: string } => {
+            const n = name.toLowerCase();
+            if (n.endsWith('.csv') || n.endsWith('.txt') || n.endsWith('.xlsx') || n.endsWith('.xls'))
+                return { cls: 'flow-tok-file', glyph: '📄' };
+            // Recordsets / memory tables / variables flowing between steps
+            if (/^rs|^mem|^v[A-Z]|recordset|memory/i.test(name)) return { cls: 'flow-tok-rs', glyph: '⬡' };
+            return { cls: asOutput ? 'flow-tok-out' : 'flow-tok-table', glyph: '▦' };
+        };
+
+        const tokenChip = (rawName: string, role: 'producer' | 'consumer', asOutput: boolean): string => {
+            const name = (rawName || '').trim();
+            if (!name || name === 'DATA' || name === 'dataset' || name === 'target') return '';
+            const key = name.toUpperCase().replace(/\s+/g, ' ');
+            const { cls, glyph } = tokenKind(name, asOutput);
+            return `<span class="flow-tok ${cls}" data-token="${ExpressionFormatter.escapeHtml(key)}" data-role="${role}"><span class="opacity-60">${glyph}</span> ${ExpressionFormatter.escapeHtml(name)}</span>`;
+        };
+
+        // A connector that carries the named data down the spine (only emitted when
+        // there is data to carry — otherwise a plain arrow).
+        const wire = (carriedHtml?: string): string =>
+            `<div class="flow-wire">${carriedHtml ? carriedHtml : ''}<span class="flow-head">▼</span></div>`;
+
+        // The in → out token row for a single step.
+        const ioRow = (item: any): string => {
+            const ins = (item.Inputs || []).map((i: string) => tokenChip(i, 'consumer', false)).filter(Boolean);
+            const outs = (item.Outputs || []).map((o: string) => tokenChip(o, 'producer', true)).filter(Boolean);
+            if (ins.length === 0 && outs.length === 0) return '';
+            const inPart = ins.length ? `<span class="text-slate-400">in</span> ${ins.join(' ')}` : '';
+            const outPart = outs.length ? `<span class="text-slate-400">out</span> ${outs.join(' ')}` : '';
+            const arrow = ins.length && outs.length ? `<span class="text-slate-300">→</span>` : '';
+            return `<div class="flex items-center gap-1.5 text-xs flex-wrap mb-2">${inPart} ${arrow} ${outPart}</div>`;
+        };
+
         html += `
-            <div class="pt-4 pb-2 space-y-1 px-2">
+            <div class="flow-spine flex flex-col items-center pt-4 pb-2 px-2">
+        `;
+
+        // Source pills at the top of the spine (always shown; placeholder if none).
+        const { sources, targets } = extractSourcesAndTargets(flowData.executionFlow, {
+            table: (n) => n,
+            file: (n) => n,
+            target: (n) => n,
+            analyser: (n) => n,
+            emailRecipients: () => 'Email recipients',
+        });
+        const sourcePills = sources.length
+            ? sources
+                  .map((s) => tokenChip(s, 'producer', false))
+                  .filter(Boolean)
+                  .join(' ')
+            : `<span class="flow-tok flow-tok-empty">none · generated internally</span>`;
+        html += `
+            <div class="flow-node text-center">
+                <div class="text-[10px] uppercase tracking-widest text-slate-400 font-bold mb-2">Sources</div>
+                <div class="flex gap-2 flex-wrap justify-center max-w-2xl">${sourcePills}</div>
+            </div>
+            ${wire()}
         `;
 
         // --- Recursive Step Renderer ---
@@ -440,7 +498,7 @@ export class EtlGenerator {
             // --- Render ---
             // If Group/Loop -> Container with Boundary
             if (isGroup) {
-                let childrenHtml = item.children.map((child: any) => renderStep(child)).join('');
+                let childrenHtml = renderFlow(item.children || []);
 
                 // Container Logic (Group, Loop, Decision, Branch)
                 const isLoop = item.RawType === 'Loop';
@@ -476,11 +534,11 @@ export class EtlGenerator {
                 const stepId = item.id || item.StepId || '';
                 const stepAnchorId = stepId ? `step-${stepId.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
                 return `
-                    <div class="mt-4 mb-4 border-2 rounded-lg ${borderColor} ${bodyColor} overflow-hidden shadow-sm"${stepAnchorId ? ` id="${stepAnchorId}"` : ''}>
+                    <div class="flow-node w-full max-w-lg mt-1 mb-1 border-2 rounded-xl ${borderColor} ${bodyColor} overflow-hidden shadow-sm"${stepAnchorId ? ` id="${stepAnchorId}"` : ''}>
                         <details class="group" open>
                             <summary class="cursor-pointer list-none px-3 py-2 ${headerColor} border-b-2 ${borderColor} flex items-center justify-between hover:opacity-90">
                                  <div class="flex items-center gap-2">
-                                     
+
                                      <span class="${iconColor} font-bold font-mono text-lg">${icon}</span>
                                      <span class="font-bold text-slate-800 text-sm">${item.Phase}: ${item.Step}</span>
                                  </div>
@@ -491,7 +549,7 @@ export class EtlGenerator {
                                     ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
                                     ${item.SmartDesc ? `<span class="text-xs text-blue-700 font-medium block mt-1 bg-blue-50 p-1 rounded border border-blue-100">💡 ${ExpressionFormatter.escapeHtml(item.SmartDesc)}</span>` : ''}
                                 </div>
-                                <div class="pl-2 space-y-4">
+                                <div class="flow-spine flex flex-col items-center">
                                     ${childrenHtml}
                                 </div>
                             </div>
@@ -554,41 +612,71 @@ export class EtlGenerator {
             const stepAnchorId = stepId ? `step-${stepId.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
 
             return `
-                <div class="relative pl-6 pb-6 border-l-2 border-slate-200 last:border-0 ml-2"${stepAnchorId ? ` id="${stepAnchorId}"` : ''}>
-                    <div class="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-white border-2 border-slate-300"></div>
+                <details class="flow-node step-collapse w-full max-w-lg rounded-xl border-2 border-slate-200 bg-white shadow-sm"${stepAnchorId ? ` id="${stepAnchorId}"` : ''}>
+                    <summary class="cursor-pointer list-none flex items-center justify-between flex-wrap gap-2 p-3 hover:bg-slate-50 rounded-xl transition-colors">
+                        <span class="font-bold text-slate-800 text-sm">${item.Step}</span>
+                        <span class="text-xs text-slate-400 font-mono">${filenameIcon ? `<span class="${filenameClass}">${filenameIcon} </span>` : ''}(${item.RawType})</span>
+                    </summary>
 
-                    <details class="step-collapse">
-                        <summary class="cursor-pointer list-none flex items-center justify-between flex-wrap gap-2 mb-1 hover:bg-slate-50 rounded px-1 -mx-1 transition-colors">
-                            <span class="font-bold text-slate-800 text-sm">${item.Step}</span>
-                            <span class="text-xs text-slate-400 font-mono">(${item.RawType})</span>
-                            ${filenameIcon ? `<span class="${filenameClass}">${filenameIcon} </span>` : ''}
-                        </summary>
+                    <div class="step-content px-3 pb-3 -mt-1">
+                        ${ioRow(item)}
+                        ${
+                            showContext
+                                ? `
+                        <div class="text-sm text-gray-600 mb-1">
+                            ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
+                            ${item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${ExpressionFormatter.escapeHtml(item.SmartDesc)}</span>` : ''}
+                        </div>`
+                                : ''
+                        }
 
-                        <div class="step-content pt-1">
-                            ${
-                                showContext
-                                    ? `
-                            <div class="text-sm text-gray-600 mb-1">
-                                ${ExpressionFormatter.colouriseTextHTML(item.Context, variableSet, tableSet)}
-                                ${item.SmartDesc ? `<span class="text-xs text-blue-600 font-medium block mt-1">💡 ${ExpressionFormatter.escapeHtml(item.SmartDesc)}</span>` : ''}
-                            </div>`
-                                    : ''
-                            }
+                        ${item.Description ? `<div class="text-xs text-slate-500 italic mb-2">Note: ${ExpressionFormatter.colouriseTextHTML(item.Description, variableSet, tableSet)}</div>` : ''}
 
-                            ${item.Description ? `<div class="text-xs text-slate-500 italic mb-2">Note: ${ExpressionFormatter.colouriseTextHTML(item.Description, variableSet, tableSet)}</div>` : ''}
-
-                            ${this.renderStepTechnicalDetails(item)}
-                            ${notesHtml}
-                            ${detailsHtml}
-                            ${tableHtml}
-                        </div>
-                    </details>
-                </div>
+                        ${this.renderStepTechnicalDetails(item)}
+                        ${notesHtml}
+                        ${detailsHtml}
+                        ${tableHtml}
+                    </div>
+                </details>
             `;
         };
 
-        html += executionTree.map((item: any) => renderStep(item)).join('');
-        html += `</div></div>`; // Close container div, Close doc-body (removed details)
+        // Interleave nodes with carried-data wires. Each wire carries the data that
+        // hands off from one step's Output to the next — emitted only when present,
+        // so the spine literally shows producer → consumer between steps.
+        const renderFlow = (items: any[]): string => {
+            return items
+                .map((item: any, idx: number) => {
+                    const nodeHtml = renderStep(item);
+                    if (idx === items.length - 1) return nodeHtml;
+                    // Carried data = this step's outputs (what flows down to the next node).
+                    const carried = (item.Outputs || [])
+                        .map((o: string) => tokenChip(o, 'consumer', true))
+                        .filter(Boolean)
+                        .join(' ');
+                    return nodeHtml + wire(carried || undefined);
+                })
+                .join('');
+        };
+
+        html += renderFlow(executionTree);
+
+        // Target pills at the bottom of the spine (always shown; placeholder if none).
+        const targetPills = targets.length
+            ? targets
+                  .map((t) => tokenChip(t, 'consumer', true))
+                  .filter(Boolean)
+                  .join(' ')
+            : `<span class="flow-tok flow-tok-empty">none · no table output</span>`;
+        html += `
+            ${wire()}
+            <div class="flow-node text-center">
+                <div class="text-[10px] uppercase tracking-widest text-slate-400 font-bold mb-2">Targets</div>
+                <div class="flex gap-2 flex-wrap justify-center max-w-2xl">${targetPills}</div>
+            </div>
+        `;
+
+        html += `</div></div>`; // Close flow-spine, Close doc-body
         return html;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,55 +75,42 @@ function formatDate(date: Date) {
     return year === currentYear ? `${day} ${month}` : `${day} ${month} ${year}`;
 }
 
-function dashboardLayout(items: any[]) {
-    const list = items
-        .map((r) => {
-            let summaryText = r.metadata.description;
-            if (r.type === 'report') {
-                try {
-                    const flowData = EtlParser.parseSteps(r.rawSteps);
-                    summaryText = EtlGenerator.generateSummary(flowData.executionFlow);
-                } catch (e) {
-                    console.error('Failed dashboard summary', e);
-                }
-            } else if (r.type === 'dashboard') {
-                try {
-                    const visualizations = r.content.Visualisations?.ArrayOfEntityDef?.EntityDef || [];
-                    const vizList = Array.isArray(visualizations) ? visualizations : [visualizations];
-                    const slicers = vizList.filter((v: any) => v.EntitySubType === 'SLICER').length;
-                    const tables = vizList.filter((v: any) => v.EntitySubType === 'TABLE').length;
-                    const charts = vizList.filter((v: any) => v.EntitySubType === 'CHART').length;
-                    summaryText = `${vizList.length} widgets: ${slicers} slicers, ${tables} tables, ${charts} charts`;
-                } catch (e) {
-                    console.error('Failed to compute widget summary', e);
-                }
-            }
+function itemSummary(r: any): string {
+    let summaryText = r.metadata.description;
+    if (r.type === 'report') {
+        try {
+            const flowData = EtlParser.parseSteps(r.rawSteps);
+            summaryText = EtlGenerator.generateSummary(flowData.executionFlow);
+        } catch (e) {
+            console.error('Failed dashboard summary', e);
+        }
+    } else if (r.type === 'dashboard') {
+        try {
+            const visualizations = r.content.Visualisations?.ArrayOfEntityDef?.EntityDef || [];
+            const vizList = Array.isArray(visualizations) ? visualizations : [visualizations];
+            const slicers = vizList.filter((v: any) => v.EntitySubType === 'SLICER').length;
+            const tables = vizList.filter((v: any) => v.EntitySubType === 'TABLE').length;
+            const charts = vizList.filter((v: any) => v.EntitySubType === 'CHART').length;
+            summaryText = `${vizList.length} widgets: ${slicers} slicers, ${tables} tables, ${charts} charts`;
+        } catch (e) {
+            console.error('Failed to compute widget summary', e);
+        }
+    }
+    return summaryText;
+}
 
-            const badgeBg =
-                r.type === 'report'
-                    ? 'bg-blue-50 text-blue-700 border-blue-200'
-                    : r.type === 'datamodel'
-                      ? 'bg-purple-50 text-purple-700 border-purple-200'
-                      : 'bg-emerald-50 text-emerald-700 border-emerald-200';
-            const badgeText = r.type === 'report' ? 'ETL' : r.type === 'datamodel' ? 'Data Model' : 'DASHBOARD';
-
-            return `
-        <div class="bg-white p-4 rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition flex justify-between items-center group relative">
-            <div class="cursor-pointer grow" onclick="window.navigateTo('detail', ${r.id}, '${r.type}')">
-                <div class="flex items-center space-x-2 mb-1">
-                    <span class="text-[0.65rem] uppercase font-bold tracking-wider px-1.5 py-0.5 rounded border ${badgeBg}">
-                        ${badgeText}
-                    </span>
-                    <h3 class="font-bold text-gray-800 group-hover:text-blue-600">${r.metadata.name}</h3>
-                </div>
-                <p class="text-xs text-gray-500">Publisher: ${r.metadata.owner} • Ver: ${r.metadata.version || '-'}</p>
-                 <p class="text-[10px] text-gray-500 mt-1 line-clamp-2 leading-tight">${summaryText}</p>
+function itemRow(r: any): string {
+    const summaryText = itemSummary(r);
+    return `
+        <div class="group flex items-center justify-between gap-4 bg-white px-4 py-3 rounded-lg border border-gray-200 hover:shadow-md hover:border-gray-300 transition cursor-pointer" onclick="window.navigateTo('detail', ${r.id}, '${r.type}')">
+            <div class="min-w-0">
+                <h3 class="font-bold text-gray-800 group-hover:text-blue-600 leading-tight truncate">${r.metadata.name}</h3>
+                <p class="text-xs text-gray-500">${r.metadata.owner} • v${r.metadata.version || '-'}</p>
+                <p class="text-[11px] text-gray-500 mt-0.5 line-clamp-1">${summaryText}</p>
             </div>
-             <div class="flex items-center space-x-4 ml-4">
-                <div class="text-xs text-gray-400 whitespace-nowrap">
-                    ${formatDate(r.dateAdded)}
-                </div>
-                <button onclick="event.stopPropagation(); window.deleteEntity(${r.id}, '${r.type}')" class="text-gray-300 hover:text-red-500 transition p-1" title="Delete">
+            <div class="flex items-center gap-4 shrink-0">
+                <span class="text-xs text-gray-400 whitespace-nowrap">${formatDate(r.dateAdded)}</span>
+                <button onclick="event.stopPropagation(); window.deleteEntity(${r.id}, '${r.type}')" class="text-gray-300 hover:text-red-500 transition p-1 opacity-0 group-hover:opacity-100" title="Delete">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
@@ -131,30 +118,81 @@ function dashboardLayout(items: any[]) {
             </div>
         </div>
     `;
-        })
-        .join('');
+}
+
+const SECTION_DEFS = [
+    { type: 'report', title: 'ETL Reports', dot: 'bg-blue-500', accent: 'border-blue-200', head: 'text-blue-700' },
+    {
+        type: 'datamodel',
+        title: 'Data Models',
+        dot: 'bg-purple-500',
+        accent: 'border-purple-200',
+        head: 'text-purple-700',
+    },
+    {
+        type: 'dashboard',
+        title: 'Dashboards',
+        dot: 'bg-emerald-500',
+        accent: 'border-emerald-200',
+        head: 'text-emerald-700',
+    },
+] as const;
+
+function dashboardLayout(items: any[]) {
+    const counts = {
+        report: items.filter((i) => i.type === 'report').length,
+        datamodel: items.filter((i) => i.type === 'datamodel').length,
+        dashboard: items.filter((i) => i.type === 'dashboard').length,
+    };
+
+    const sections = SECTION_DEFS.map((s) => {
+        const secItems = items.filter((i) => i.type === s.type);
+        if (secItems.length === 0) return '';
+        return `
+        <section>
+            <div class="flex items-center gap-2 mb-3 pb-2 border-b ${s.accent}">
+                <span class="w-2.5 h-2.5 rounded-full ${s.dot}"></span>
+                <h2 class="text-sm font-bold ${s.head}">${s.title}</h2>
+                <span class="text-xs text-gray-400">${secItems.length}</span>
+            </div>
+            <div class="space-y-2">${secItems.map(itemRow).join('')}</div>
+        </section>`;
+    }).join('');
+
+    const emptyState =
+        items.length === 0
+            ? `<div class="text-center text-gray-400 py-12">Library empty — upload a definition to get started.</div>`
+            : '';
 
     return `
     <main class="grow p-6 bg-gray-100 w-full">
-        <div class="max-w-4xl mx-auto space-y-6">
-            <!-- Upload -->
-            <div id="dropZone" class="bg-white p-10 rounded-xl shadow-sm border-2 border-dashed border-gray-300 text-center transition-all hover:border-blue-500 hover:bg-blue-50">
-                <div class="space-y-3 pointer-events-none">
-                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-50 text-blue-600 mb-2">
+        <div class="max-w-5xl mx-auto space-y-8">
+            <!-- Hero: upload + stats split -->
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div id="dropZone" class="md:col-span-2 bg-gradient-to-br from-blue-600 to-indigo-700 text-white p-8 rounded-2xl shadow-md border-2 border-transparent hover:border-blue-300 cursor-pointer transition-all flex items-center gap-5">
+                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/15 backdrop-blur shrink-0 pointer-events-none">
                         <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path></svg>
                     </div>
-                    <h2 class="text-xl font-bold text-gray-900">Upload Definitions</h2>
-                    <p class="text-sm text-gray-500">Drag & drop <code>.t1etlp</code>, <code>.t1dm</code>, or <code>.t1db</code> files here</p>
+                    <div class="pointer-events-none">
+                        <h2 class="text-2xl font-bold leading-tight">Upload Definitions</h2>
+                        <p class="text-sm text-blue-100 mt-1">Drag & drop <code class="bg-white/20 px-1 rounded">.t1etlp</code>, <code class="bg-white/20 px-1 rounded">.t1dm</code>, <code class="bg-white/20 px-1 rounded">.t1db</code> — everything stays on your device.</p>
+                    </div>
+                    <input type="file" id="fileInput" multiple accept=".t1etlp,.t1dm,.t1db" class="hidden">
                 </div>
-                  <input type="file" id="fileInput" multiple accept=".t1etlp,.t1dm,.t1db" class="hidden">
+                <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5 flex flex-col justify-center">
+                    <p class="text-[10px] uppercase font-bold tracking-wider text-gray-400 mb-3">Library (${items.length})</p>
+                    <div class="grid grid-cols-3 gap-2 text-center">
+                        <div><div class="text-2xl font-bold text-blue-600">${counts.report}</div><div class="text-[10px] text-gray-500">ETL</div></div>
+                        <div><div class="text-2xl font-bold text-purple-600">${counts.datamodel}</div><div class="text-[10px] text-gray-500">Models</div></div>
+                        <div><div class="text-2xl font-bold text-emerald-600">${counts.dashboard}</div><div class="text-[10px] text-gray-500">Dash</div></div>
+                    </div>
+                </div>
             </div>
 
-            <!-- List -->
-            <div>
-                <h2 class="text-lg font-bold text-gray-700 mb-3">Library (${items.length})</h2>
-                <div class="space-y-3">
-                    ${list}
-                </div>
+            <!-- Sections by type -->
+            <div class="space-y-8">
+                ${sections}
+                ${emptyState}
             </div>
         </div>
     </main>
@@ -219,6 +257,8 @@ async function render() {
             const container = document.getElementById('detailContainer');
             if (container) {
                 container.innerHTML = html;
+                // Wire flow-diagram lineage (hover to trace, click to pin)
+                wireFlowLineage(container);
                 // Initialize Mermaid if charts are present
                 if (container.querySelector('.mermaid')) {
                     try {
@@ -247,6 +287,63 @@ async function render() {
     if (currentView === 'dashboard') {
         setupDragAndDrop();
     }
+}
+
+/**
+ * Wire the linked-flow lineage interaction. Tokens carry data-token (normalized
+ * name) and data-role (producer|consumer). Hovering a chip lights every chip of
+ * the same token (producer marked "made here", others "used") and dims the rest;
+ * clicking pins that lineage so it persists while scrolling. Click again, click a
+ * different token, or click empty space to clear.
+ */
+function wireFlowLineage(container: HTMLElement) {
+    const toks = Array.from(container.querySelectorAll<HTMLElement>('.flow-tok[data-token]'));
+    if (toks.length === 0) return;
+    let pinned: string | null = null;
+
+    const clear = () => {
+        toks.forEach((t) => t.classList.remove('dim', 'lit', 'is-producer', 'is-consumer', 'pinned'));
+    };
+
+    const highlight = (name: string, pin: boolean) => {
+        clear();
+        toks.forEach((t) => {
+            if (t.dataset.token === name) {
+                t.classList.add('lit');
+                t.classList.add(t.dataset.role === 'producer' ? 'is-producer' : 'is-consumer');
+                if (pin) t.classList.add('pinned');
+            } else {
+                t.classList.add('dim');
+            }
+        });
+    };
+
+    toks.forEach((tok) => {
+        const name = tok.dataset.token!;
+        tok.addEventListener('mouseenter', () => {
+            if (pinned) return; // pinned lineage takes precedence over hover
+            highlight(name, false);
+        });
+        tok.addEventListener('mouseleave', () => {
+            if (pinned) return;
+            clear();
+        });
+        tok.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (tok.classList.contains('flow-tok-empty')) return;
+            pinned = pinned === name ? null : name;
+            if (pinned) highlight(name, true);
+            else clear();
+        });
+    });
+
+    // Click anywhere else clears a pin.
+    container.addEventListener('click', () => {
+        if (pinned) {
+            pinned = null;
+            clear();
+        }
+    });
 }
 
 function setupDragAndDrop() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,8 +75,20 @@ function formatDate(date: Date) {
     return year === currentYear ? `${day} ${month}` : `${day} ${month} ${year}`;
 }
 
+/** Escape user-controlled text before interpolating into innerHTML (uploaded
+ *  definition metadata is untrusted — prevents stored XSS via crafted files). */
+function escapeHtml(val: unknown): string {
+    return String(val ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
 function itemSummary(r: any): string {
-    let summaryText = r.metadata.description;
+    // Default path: raw user-supplied description — must be escaped.
+    let summaryText = escapeHtml(r.metadata.description);
     if (r.type === 'report') {
         try {
             const flowData = EtlParser.parseSteps(r.rawSteps);
@@ -104,8 +116,8 @@ function itemRow(r: any): string {
     return `
         <div class="group flex items-center justify-between gap-4 bg-white px-4 py-3 rounded-lg border border-gray-200 hover:shadow-md hover:border-gray-300 transition cursor-pointer" onclick="window.navigateTo('detail', ${r.id}, '${r.type}')">
             <div class="min-w-0">
-                <h3 class="font-bold text-gray-800 group-hover:text-blue-600 leading-tight truncate">${r.metadata.name}</h3>
-                <p class="text-xs text-gray-500">${r.metadata.owner} • v${r.metadata.version || '-'}</p>
+                <h3 class="font-bold text-gray-800 group-hover:text-blue-600 leading-tight truncate">${escapeHtml(r.metadata.name)}</h3>
+                <p class="text-xs text-gray-500">${escapeHtml(r.metadata.owner)} • v${escapeHtml(r.metadata.version || '-')}</p>
                 <p class="text-[11px] text-gray-500 mt-0.5 line-clamp-1">${summaryText}</p>
             </div>
             <div class="flex items-center gap-4 shrink-0">
@@ -320,20 +332,46 @@ function wireFlowLineage(container: HTMLElement) {
 
     toks.forEach((tok) => {
         const name = tok.dataset.token!;
-        tok.addEventListener('mouseenter', () => {
-            if (pinned) return; // pinned lineage takes precedence over hover
+        const isEmpty = tok.classList.contains('flow-tok-empty');
+
+        // Keyboard accessibility: make real tokens focusable buttons so keyboard /
+        // assistive-tech users can trace and pin lineage too (empty placeholders
+        // are non-interactive and stay out of the tab order).
+        if (!isEmpty) {
+            tok.tabIndex = 0;
+            tok.setAttribute('role', 'button');
+            tok.setAttribute('aria-label', `Trace data lineage for ${name}`);
+        }
+
+        const preview = () => {
+            if (pinned) return; // pinned lineage takes precedence over hover/focus
             highlight(name, false);
-        });
-        tok.addEventListener('mouseleave', () => {
+        };
+        const unpreview = () => {
             if (pinned) return;
             clear();
-        });
-        tok.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (tok.classList.contains('flow-tok-empty')) return;
+        };
+        const toggle = () => {
+            if (isEmpty) return;
             pinned = pinned === name ? null : name;
             if (pinned) highlight(name, true);
             else clear();
+        };
+
+        tok.addEventListener('mouseenter', preview);
+        tok.addEventListener('mouseleave', unpreview);
+        tok.addEventListener('focus', preview);
+        tok.addEventListener('blur', unpreview);
+        tok.addEventListener('click', (e) => {
+            e.stopPropagation();
+            toggle();
+        });
+        tok.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                toggle();
+            }
         });
     });
 

--- a/src/style.css
+++ b/src/style.css
@@ -300,6 +300,90 @@ details[open]>summary::after {
   opacity: 1;
 }
 
+/* ===== Linked Flow Diagram ===== */
+
+/* Continuous spine: one vertical line threading every node in a column. */
+.flow-spine {
+  position: relative;
+}
+.flow-spine::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #cbd5e1;
+  transform: translateX(-50%);
+  z-index: 0;
+}
+.flow-spine > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Connector carrying the flowing data down the spine. */
+.flow-wire {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.3rem 0;
+}
+.flow-head {
+  color: #cbd5e1;
+  font-size: 0.8rem;
+  line-height: 0.4;
+}
+
+/* Token chips — identical look wherever a given name appears, so the eye
+   links producer to consumer. data-token is the link key. */
+.flow-tok {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.05rem 0.45rem;
+  border-radius: 0.3rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: box-shadow 0.12s, transform 0.12s, opacity 0.12s;
+  white-space: nowrap;
+}
+.flow-tok-table { background: #dbeafe; color: #1e40af; border: 1px solid #93c5fd; }
+.flow-tok-out   { background: #dcfce7; color: #15803d; border: 1px solid #86efac; }
+.flow-tok-rs    { background: #f3e8ff; color: #7e22ce; border: 1px solid #d8b4fe; }
+.flow-tok-file  { background: #dcfce7; color: #15803d; border: 1px solid #86efac; }
+.flow-tok-empty {
+  background: #f8fafc;
+  color: #94a3b8;
+  border: 1px dashed #cbd5e1;
+  font-style: italic;
+  cursor: default;
+}
+/* Data riding a wire gets a dashed outline to read as "in transit". */
+.flow-wire .flow-tok { background: #fff; border-style: dashed; }
+
+/* Hover / pinned lineage highlight. */
+.flow-tok.dim { opacity: 0.3; }
+.flow-tok.lit { box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.4); transform: translateY(-1px); z-index: 5; }
+.flow-tok.is-producer::after {
+  content: '▲ made here';
+  font-size: 0.55rem;
+  font-weight: 600;
+  margin-left: 0.25rem;
+  opacity: 0.7;
+}
+.flow-tok.is-consumer::after {
+  content: 'used';
+  font-size: 0.55rem;
+  font-weight: 600;
+  margin-left: 0.25rem;
+  opacity: 0.55;
+}
+.flow-tok.pinned { box-shadow: 0 0 0 3px rgba(217, 70, 239, 0.55); }
+
  /* Step Output Badge (String) */
  .t1-step-output-badge {
       display: inline-flex;

--- a/src/style.css
+++ b/src/style.css
@@ -384,6 +384,12 @@ details[open]>summary::after {
 }
 .flow-tok.pinned { box-shadow: 0 0 0 3px rgba(217, 70, 239, 0.55); }
 
+/* Visible focus ring for keyboard navigation of tokens. */
+.flow-tok:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
  /* Step Output Badge (String) */
  .t1-step-output-badge {
       display: inline-flex;


### PR DESCRIPTION
## What

Replaces the flat, indented **step timeline** in the ETL report detail view with an interactive **linked flow diagram** that makes the data path readable at a glance.

## Why

The old timeline listed steps top-to-bottom but buried the actual data movement in prose. There was no visual link between where a dataset (table / recordset / variable) was *produced* and where it was *consumed*, so following an ETL's flow meant reading every step carefully. This is the core thing the tool is meant to make easy.

## How

Driven entirely by existing parser output — **no data-model or parser changes**.

- **Continuous spine** threads `Sources → step nodes → Targets` as one unbroken pipeline (nested spine inside group/loop/decision boundaries).
- **Source/target blocks always shown**, with dashed placeholders when an ETL has no table I/O (generates internally, email/file-only, validation-only) — so odd-shaped ETLs render honestly instead of looking broken.
- **Expandable step nodes** show an `in → out` token row up top; all existing detail (filters, output schema, exists-logic, step notes, technical settings) is preserved inside on expand.
- **Carried-data connectors** label what hands off between consecutive steps — one step's `Output` = the next step's `Input`, visible on the wire (only where data is named).
- **Matching token chips**: the same normalized name looks identical everywhere it appears, so the eye links producer → consumer. Coloured by kind (table = blue, output = green, recordset/var = purple, file = green).
- **Hover-to-trace lineage**: hover a chip → all matching chips light up (producer marked "made here", consumers "used"), the rest dim. **Click to pin** so the lineage persists while scrolling; click again / elsewhere to clear.

## Files

- `src/lib/generators/EtlGenerator.ts` — flow renderer (`tokenChip` / `wire` / `ioRow` / `renderFlow`), source/target pills, nested-spine group rendering.
- `src/style.css` — `.flow-spine`, `.flow-wire`, `.flow-tok-*`, hover/pin highlight states.
- `src/main.ts` — `wireFlowLineage()` wired after detail HTML injection (hover + click-pin listeners).

## Reviewer notes

- Token kind is inferred from a **name heuristic** (`rs*` / `mem*` / `v[A-Z]*` → recordset, `.csv/.txt/.xlsx` → file, else table). Tune the regex in `tokenKind` if real recordset naming diverges.
- The old detailed-timeline markup is **gone** — all per-step detail now lives inside the expandable nodes. Mermaid "Process Flow" chart is untouched (separate block).
- Verified against `samples/ETLs/AFRG_I&E_CORE_DATA`: 12 nodes, 10 wires, nested loop spine, repeated producer/consumer tokens link correctly; hover/pin highlight confirmed via DOM.
- `tsc` clean · `vite build` clean · **57/57 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
