### PR TITLE
feat(etl): advanced logic for Group/StartProcess/Script/DTS steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We are currently acting as a "Beta" for the **ETL** and **Data Model** modules. 
 
 ### 🔄 Module: Integration & ETL (Current)
 - [x] **ETL Parser (`.t1etlp`)**: Full step-by-step visualisation, loop handling, and logic extraction.
-- [ ] **Advanced Logic**: Better distinct handling for `StartProcess`, `Script`, and `DTS` tasks.
+- [x] **Advanced Logic**: Better distinct handling for `StartProcess`, `Script`, and `DTS` tasks.
 
 ### 📊 Module: BI & Analytics (Active Development)
 - [x] **Data Models (`.t1dm`)**:

--- a/docs/FILE_FORMATS.md
+++ b/docs/FILE_FORMATS.md
@@ -753,3 +753,22 @@ These step types exist in TechnologyOne but haven't been observed in sample file
 - Source: `src/lib/FileProcessor.ts` - Main file ingestion
 - Source: `src/lib/parsers/EtlParser.ts` - ETL parsing logic
 - Source: `src/lib/parsers/DataModelParser.ts` - Data Model parsing logic
+
+## Advanced step types — UNVERIFIED field names
+
+`StartProcess`, `Script`, and `DTS` step types are parsed defensively because no
+sample `.t1etlp` in this repo contains them and TechnologyOne's ETL XML schema is
+not publicly documented. The parser (`src/lib/parsers/StepDescriptors.ts`) tries
+multiple candidate keys per field and degrades gracefully if none match. **These
+key names are assumptions — correct them against a real file when available.**
+
+| Step type    | Field        | Candidate keys (first non-empty wins)                      |
+| ------------ | ------------ | ---------------------------------------------------------- |
+| StartProcess | process name | `ProcessName`, `ProcessToRun`, `Process`, `SubProcessName` |
+| Script       | language     | `ScriptLanguage`, `Language`                               |
+| Script       | body         | `ScriptText`, `Script`                                     |
+| DTS          | package      | `DTSPackageName`, `PackageName`, `DTSPackage`, `Package`   |
+| DTS          | connection   | `ConnectionString`, `Connection`, `DTSConnection`          |
+
+`Group` handling is verified against real sample data (the step `<Name>` is the
+label; children attach via `ParentStepId`).

--- a/docs/superpowers/plans/2026-06-07-etl-advanced-logic.md
+++ b/docs/superpowers/plans/2026-06-07-etl-advanced-logic.md
@@ -1,0 +1,802 @@
+# ETL Advanced Logic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the ETL parser distinct, first-class handling for `Group`, `StartProcess`, `Script`, and `DTS` step types instead of generic fallbacks.
+
+**Architecture:** Extract a new `StepDescriptors.ts` module holding one pure descriptor function per target step type (helpers injected from `EtlParser`). `EtlParser.traverse()` delegates these four types to the module inside a try/catch, merging the result into the existing `EtlStep` object; all other types keep their current inline logic. Render paths (`EtlGenerator`, `MermaidGenerator`) gain icons/shapes for the three new standard-step types — `Group` already renders as a container.
+
+**Tech Stack:** TypeScript, Vitest, fast-xml-parser tree shapes (`XmlNode`/`XmlValue`/`asNode`), Vite.
+
+**Confidence tiers:** `Group` is verified against real sample data. `StartProcess`/`Script`/`DTS` field names are UNVERIFIED (proprietary T1 schema, no samples) — extraction is defensive multi-key, de-risked by tests modeling the assumed shapes.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-etl-advanced-logic-design.md`
+
+**Test command:** `pnpm vitest run <file>` (project uses `vitest`). Tests build plain JS mock objects (already-parsed XML), call `EtlParser.parseSteps`, and assert on the returned tree — see `tests/EtlParser.test.ts`.
+
+---
+
+## File Structure
+
+- **Create** `src/lib/parsers/StepDescriptors.ts` — descriptor lookup + helpers interface. One responsibility: turn a step's storage into display/lineage fields for the four target types.
+- **Create** `tests/StepDescriptors.test.ts` — unit tests for the descriptor module + integration tests through `parseSteps`.
+- **Modify** `src/lib/parsers/EtlParser.ts` — export `RawStep`; delegate the four types to descriptors inside `traverse()`; delegate `getExplicitOutput` for these types.
+- **Modify** `src/lib/parsers/types.ts` — add optional `Icon?: string` to `EtlStep`.
+- **Modify** `src/lib/generators/EtlGenerator.ts` — icon map for `Script`/`StartProcess`/`DTS`.
+- **Modify** `src/lib/generators/MermaidGenerator.ts` — shape/class for `Script`/`StartProcess`/`DTS`.
+- **Modify** `docs/FILE_FORMATS.md` — document Tier-B UNVERIFIED candidate keys.
+
+---
+
+### Task 1: Add `Icon` field + export `RawStep`
+
+**Files:**
+- Modify: `src/lib/parsers/types.ts:37-41`
+- Modify: `src/lib/parsers/EtlParser.ts:5-6`
+
+- [ ] **Step 1: Add optional `Icon` to `EtlStep`**
+
+In `src/lib/parsers/types.ts`, inside the `EtlStep` interface, after the `Value?: string;` line (line 41), add:
+
+```ts
+    /** Display glyph for this step type (single source of truth for HTML + Mermaid). */
+    Icon?: string;
+```
+
+- [ ] **Step 2: Export `RawStep` from `EtlParser`**
+
+In `src/lib/parsers/EtlParser.ts`, change line 6 from:
+
+```ts
+type RawStep = XmlNode & { children?: RawStep[] };
+```
+
+to:
+
+```ts
+export type RawStep = XmlNode & { children?: RawStep[] };
+```
+
+- [ ] **Step 3: Verify the project still type-checks**
+
+Run: `pnpm tsc --noEmit`
+Expected: PASS (no errors). `Icon` is optional and additive; `export` is additive.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/parsers/types.ts src/lib/parsers/EtlParser.ts
+git commit -m "feat(etl): add optional Icon field and export RawStep"
+```
+
+---
+
+### Task 2: Create `StepDescriptors` module with the `Group` descriptor (Tier A)
+
+**Files:**
+- Create: `src/lib/parsers/StepDescriptors.ts`
+- Test: `tests/StepDescriptors.test.ts`
+
+- [ ] **Step 1: Write the failing test for the Group descriptor**
+
+Create `tests/StepDescriptors.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { STEP_DESCRIPTORS, makeHelpers } from '../src/lib/parsers/StepDescriptors';
+import type { RawStep } from '../src/lib/parsers/EtlParser';
+
+const h = makeHelpers();
+
+describe('StepDescriptors', () => {
+    describe('Group', () => {
+        it('uses the step Name as label and counts children', () => {
+            const step: RawStep = {
+                StepType: 'Group',
+                Name: 'Prep Chart of Accounts',
+                Definition: { StorageObject: { DefKey: 'abc' } },
+                children: [{ StepType: 'RunDirectQuery' }, { StepType: 'AddColumn' }],
+            };
+            const storage = { DefKey: 'abc' };
+            const d = STEP_DESCRIPTORS['Group'](storage, step, h);
+            expect(d.contextText).toBe('Prep Chart of Accounts');
+            expect(d.flowLabel).toBe('Prep Chart of Accounts');
+            expect(d.smartDesc).toBe('Groups 2 steps');
+            expect(d.icon).toBe('🗂️');
+            expect(d.inputs).toEqual([]);
+            expect(d.outputs).toEqual([]);
+            expect(d.explicitOutput).toBeNull();
+        });
+
+        it('falls back to "Group" when Name is empty', () => {
+            const step: RawStep = { StepType: 'Group', Name: '', children: [] };
+            const d = STEP_DESCRIPTORS['Group']({}, step, h);
+            expect(d.contextText).toBe('Group');
+            expect(d.smartDesc).toBe('Groups 0 steps');
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: FAIL — cannot resolve module `StepDescriptors` (not created yet).
+
+- [ ] **Step 3: Create the module with helpers + Group descriptor**
+
+Create `src/lib/parsers/StepDescriptors.ts`:
+
+```ts
+import type { XmlNode, XmlValue } from './types';
+import { asNode } from './types';
+import type { RawStep } from './EtlParser';
+
+/** Display + lineage fields a descriptor produces for one step. */
+export interface StepDescriptor {
+    contextText: string;
+    flowLabel: string;
+    details: string[];
+    inputs: string[];
+    outputs: string[];
+    explicitOutput: { type: string; name: string } | null;
+    icon?: string;
+    smartDesc?: string;
+}
+
+/** Leaf/list readers injected by EtlParser so this module stays decoupled. */
+export interface DescriptorHelpers {
+    getTextSafe: (v: XmlValue) => string;
+    getListSafe: (v: XmlValue, key: string) => XmlNode[];
+    /** Returns the first non-empty text value among the candidate keys. */
+    firstOf: (storage: XmlNode, keys: string[]) => string;
+}
+
+export type DescriptorFn = (storage: XmlNode, step: RawStep, h: DescriptorHelpers) => StepDescriptor;
+
+/**
+ * Standalone helper factory (used by tests and as a fallback). EtlParser passes
+ * its own statics in production so behavior matches the rest of the parser.
+ */
+export function makeHelpers(): DescriptorHelpers {
+    const getTextSafe = (val: XmlValue): string => {
+        if (val == null || val === '') return '';
+        if (typeof val === 'string') return val;
+        if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+        const node = asNode(val);
+        if (node && typeof node['#text'] === 'string') return node['#text'];
+        return '';
+    };
+    const getListSafe = (obj: XmlValue, key: string): XmlNode[] => {
+        const node = asNode(obj);
+        if (!node || node[key] == null) return [];
+        const v = node[key];
+        return (Array.isArray(v) ? v : [v]) as XmlNode[];
+    };
+    const firstOf = (storage: XmlNode, keys: string[]): string => {
+        for (const k of keys) {
+            const t = getTextSafe(storage[k]);
+            if (t && t.trim().length > 0) return t.trim();
+        }
+        return '';
+    };
+    return { getTextSafe, getListSafe, firstOf };
+}
+
+const groupDescriptor: DescriptorFn = (_storage, step, h) => {
+    const name = h.getTextSafe(step.Name) || 'Group';
+    const count = (step.children || []).length;
+    return {
+        contextText: name,
+        flowLabel: name,
+        details: [],
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '🗂️',
+        smartDesc: `Groups ${count} steps`,
+    };
+};
+
+export const STEP_DESCRIPTORS: Record<string, DescriptorFn> = {
+    Group: groupDescriptor,
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: PASS (both Group tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/parsers/StepDescriptors.ts tests/StepDescriptors.test.ts
+git commit -m "feat(etl): add StepDescriptors module with Group descriptor"
+```
+
+---
+
+### Task 3: Add `Script`, `StartProcess`, `DTS` descriptors (Tier B — defensive)
+
+**Files:**
+- Modify: `src/lib/parsers/StepDescriptors.ts`
+- Test: `tests/StepDescriptors.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/StepDescriptors.test.ts` inside the top-level `describe('StepDescriptors', ...)` block (before its closing `});`):
+
+```ts
+    describe('Script', () => {
+        it('extracts language and truncates body preview', () => {
+            const body = 'x'.repeat(200);
+            const storage = { ScriptLanguage: 'VBScript', ScriptText: body };
+            const d = STEP_DESCRIPTORS['Script'](storage, { StepType: 'Script' }, h);
+            expect(d.flowLabel).toBe('Script: VBScript');
+            expect(d.icon).toBe('📜');
+            expect(d.details.some((l) => l.startsWith('Language: VBScript'))).toBe(true);
+            expect(d.details.some((l) => l.includes('...'))).toBe(true);
+        });
+
+        it('reads alternate keys and degrades without language', () => {
+            const storage = { Language: 'PowerShell', Script: 'Get-Date' };
+            const d = STEP_DESCRIPTORS['ExecuteScript'](storage, { StepType: 'ExecuteScript' }, h);
+            expect(d.flowLabel).toBe('Script: PowerShell');
+            const bare = STEP_DESCRIPTORS['Script']({}, { StepType: 'Script' }, h);
+            expect(bare.flowLabel).toBe('Script');
+        });
+    });
+
+    describe('StartProcess', () => {
+        it('extracts process name, params, and output token', () => {
+            const storage = {
+                ProcessName: 'NightlyRollup',
+                Parameters: { ParameterItem: [{ Name: 'Year', Value: '2026' }] },
+            };
+            const d = STEP_DESCRIPTORS['StartProcess'](storage, { StepType: 'StartProcess' }, h);
+            expect(d.flowLabel).toBe('Run: NightlyRollup');
+            expect(d.icon).toBe('▶');
+            expect(d.explicitOutput).toEqual({ type: 'PROCESS', name: 'NightlyRollup' });
+            expect(d.details.some((l) => l === 'Param: Year = 2026')).toBe(true);
+        });
+
+        it('reads alternate process key', () => {
+            const d = STEP_DESCRIPTORS['RunProcess']({ ProcessToRun: 'P2' }, { StepType: 'RunProcess' }, h);
+            expect(d.flowLabel).toBe('Run: P2');
+        });
+    });
+
+    describe('DTS', () => {
+        it('extracts package name and connection', () => {
+            const storage = { DTSPackageName: 'LoadGL', ConnectionString: 'Server=x' };
+            const d = STEP_DESCRIPTORS['DTS'](storage, { StepType: 'DTS' }, h);
+            expect(d.flowLabel).toBe('DTS: LoadGL');
+            expect(d.icon).toBe('🔀');
+            expect(d.details.some((l) => l.startsWith('Connection: Server=x'))).toBe(true);
+        });
+
+        it('degrades to bare label when package missing', () => {
+            const d = STEP_DESCRIPTORS['RunDTS']({}, { StepType: 'RunDTS' }, h);
+            expect(d.flowLabel).toBe('DTS');
+        });
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: FAIL — `STEP_DESCRIPTORS['Script']` (and `StartProcess`/`DTS` and their aliases) are `undefined`.
+
+- [ ] **Step 3: Implement the three descriptors + register aliases**
+
+In `src/lib/parsers/StepDescriptors.ts`, add these three descriptor functions after `groupDescriptor`:
+
+```ts
+const scriptDescriptor: DescriptorFn = (storage, _step, h) => {
+    const lang = h.firstOf(storage, ['ScriptLanguage', 'Language']);
+    const body = h.firstOf(storage, ['ScriptText', 'Script']);
+    const details: string[] = [];
+    if (lang) details.push(`Language: ${lang}`);
+    if (body) {
+        const preview = body.length > 150 ? body.substring(0, 150) + '...' : body;
+        details.push(`Script: ${preview}`);
+    }
+    const label = lang ? `Script: ${lang}` : 'Script';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '📜',
+    };
+};
+
+const startProcessDescriptor: DescriptorFn = (storage, _step, h) => {
+    const proc = h.firstOf(storage, ['ProcessName', 'ProcessToRun', 'Process', 'SubProcessName']);
+    const details: string[] = [];
+    if (proc) details.push(`Process: ${proc}`);
+    h.getListSafe(storage.Parameters, 'ParameterItem').forEach((p) => {
+        details.push(`Param: ${h.getTextSafe(p.Name)} = ${h.getTextSafe(p.Value)}`);
+    });
+    const label = proc ? `Run: ${proc}` : 'Run Process';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: proc ? [proc] : [],
+        explicitOutput: proc ? { type: 'PROCESS', name: proc } : null,
+        icon: '▶',
+    };
+};
+
+const dtsDescriptor: DescriptorFn = (storage, _step, h) => {
+    const pkg = h.firstOf(storage, ['DTSPackageName', 'PackageName', 'DTSPackage', 'Package']);
+    const conn = h.firstOf(storage, ['ConnectionString', 'Connection', 'DTSConnection']);
+    const details: string[] = [];
+    if (pkg) details.push(`Package: ${pkg}`);
+    if (conn) details.push(`Connection: ${conn}`);
+    const label = pkg ? `DTS: ${pkg}` : 'DTS';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '🔀',
+    };
+};
+```
+
+Then replace the `STEP_DESCRIPTORS` export with:
+
+```ts
+export const STEP_DESCRIPTORS: Record<string, DescriptorFn> = {
+    Group: groupDescriptor,
+    Script: scriptDescriptor,
+    ExecuteScript: scriptDescriptor,
+    StartProcess: startProcessDescriptor,
+    RunProcess: startProcessDescriptor,
+    DTS: dtsDescriptor,
+    ExecuteDTS: dtsDescriptor,
+    RunDTS: dtsDescriptor,
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: PASS (all Group/Script/StartProcess/DTS tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/parsers/StepDescriptors.ts tests/StepDescriptors.test.ts
+git commit -m "feat(etl): add Script/StartProcess/DTS descriptors (defensive)"
+```
+
+---
+
+### Task 4: Wire descriptors into `EtlParser.traverse()`
+
+**Files:**
+- Modify: `src/lib/parsers/EtlParser.ts` (imports near top; `getExplicitOutput` ~181-201; inside `traverse` ~367-543)
+- Test: `tests/StepDescriptors.test.ts`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append a new top-level block to `tests/StepDescriptors.test.ts` (after the `describe('StepDescriptors', ...)` block):
+
+```ts
+import { EtlParser } from '../src/lib/parsers/EtlParser';
+
+describe('parseSteps integration — advanced step types', () => {
+    const wrap = (steps: any[]) => ({ ArrayOfStep: { Step: steps } });
+
+    it('labels a Group by its Name with a child count', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'Group', Name: 'Prep COA',
+                  Definition: { StorageObject: { DefKey: 'g1' } } },
+                { StepId: '2', ParentStepId: '1', Sequence: '1', StepType: 'AddColumn', Name: 'Calc',
+                  Definition: { StorageObject: { Columns: { ColumnItemDef: { ColumnName: 'X', Expression: '1' } } } } },
+            ])
+        ).executionTree;
+        const group = tree[0];
+        expect(group.RawType).toBe('Group');
+        expect(group.FlowLabel).toBe('Prep COA');
+        expect(group.Context).toBe('Prep COA');
+        expect(group.SmartDesc).toBe('Groups 1 steps');
+        expect(group.Icon).toBe('🗂️');
+        expect(group.children).toHaveLength(1);
+    });
+
+    it('describes a StartProcess step', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'StartProcess', Name: 'Kick',
+                  Definition: { StorageObject: { ProcessName: 'NightlyRollup' } } },
+            ])
+        ).executionTree;
+        expect(tree[0].FlowLabel).toBe('Run: NightlyRollup');
+        expect(tree[0].Icon).toBe('▶');
+        expect(tree[0].Output).toEqual({ type: 'PROCESS', name: 'NightlyRollup' });
+    });
+
+    it('does not crash on a malformed StartProcess (no candidate keys)', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'StartProcess', Name: 'Empty',
+                  Definition: { StorageObject: {} } },
+            ])
+        ).executionTree;
+        expect(tree[0].RawType).toBe('StartProcess');
+        expect(tree[0].FlowLabel).toBe('Run Process');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: FAIL — `FlowLabel` for Group is `"Group"`, `Icon` is `undefined`, StartProcess `Output` is `null` (descriptors not wired into parser yet).
+
+- [ ] **Step 3: Import descriptors in `EtlParser`**
+
+In `src/lib/parsers/EtlParser.ts`, after the existing imports (after line 3), add:
+
+```ts
+import { STEP_DESCRIPTORS, makeHelpers, type StepDescriptor } from './StepDescriptors';
+```
+
+Then, immediately after the `export class EtlParser {` line (line 8), add a shared helpers instance bound to the parser's own statics:
+
+```ts
+    private static descriptorHelpers = {
+        getTextSafe: (v: XmlValue) => EtlParser.getTextSafe(v),
+        getListSafe: (v: XmlValue, key: string) => EtlParser.getListSafe(v, key),
+        firstOf: makeHelpers().firstOf,
+    };
+```
+
+- [ ] **Step 4: Delegate `getExplicitOutput` for the four types**
+
+In `src/lib/parsers/EtlParser.ts`, at the very start of the `getExplicitOutput` method body (right after line 181 `getExplicitOutput(stepType: string, storage: XmlNode, _step: XmlValue) {`), add:
+
+```ts
+        const descriptor = STEP_DESCRIPTORS[stepType];
+        if (descriptor) {
+            try {
+                return descriptor(storage, _step as RawStep, this.descriptorHelpers).explicitOutput;
+            } catch {
+                return null;
+            }
+        }
+```
+
+- [ ] **Step 5: Delegate display fields inside `traverse`**
+
+In `src/lib/parsers/EtlParser.ts`, inside `traverse`, locate the block that sets `info.FlowLabel = fl;` (line ~590). Immediately **after** that line, add:
+
+```ts
+            // --- Advanced step descriptors (Group / Script / StartProcess / DTS) ---
+            const advDescriptor = STEP_DESCRIPTORS[stepType];
+            if (advDescriptor) {
+                try {
+                    const d: StepDescriptor = advDescriptor(storage, step, this.descriptorHelpers);
+                    info.Context = d.contextText;
+                    info.FlowLabel = d.flowLabel;
+                    if (d.icon) info.Icon = d.icon;
+                    if (d.smartDesc) info.SmartDesc = d.smartDesc;
+                    if (d.inputs.length) info.Inputs = d.inputs;
+                    if (d.outputs.length) info.Outputs = d.outputs;
+                    d.details.forEach((line) => {
+                        if (!info.Details.includes(line)) info.Details.push(line);
+                    });
+                } catch (e) {
+                    console.error(`Descriptor failed for ${stepType}:`, e);
+                    // Fall back to the generic context already set above.
+                }
+            }
+```
+
+> Note: this runs after the existing `switch`/detail logic, so for `Script`/`StartProcess`/`DTS` it *augments* (and overrides label/context) the prior inline handling rather than removing it. Duplicate detail lines are de-duped by the `includes` guard. The old inline `else if` blocks for `Script`/`StartProcess` (lines ~797–822) stay in place — harmless, deduped — and are removed in Task 5.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: PASS (all integration tests).
+
+- [ ] **Step 7: Run the full parser suite for regressions**
+
+Run: `pnpm vitest run tests/EtlParser.test.ts tests/EtlParser.KitchenSink.test.ts`
+Expected: PASS (no regressions — other step types untouched).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/parsers/EtlParser.ts tests/StepDescriptors.test.ts
+git commit -m "feat(etl): wire advanced descriptors into traverse and getExplicitOutput"
+```
+
+---
+
+### Task 5: Remove now-duplicated inline `Script`/`StartProcess` detail blocks
+
+**Files:**
+- Modify: `src/lib/parsers/EtlParser.ts:797-823`
+
+- [ ] **Step 1: Delete the superseded inline blocks**
+
+In `src/lib/parsers/EtlParser.ts`, remove the three `else if` branches that the descriptors now own — the `Script`/`ExecuteScript` block, and the `StartProcess`/`RunProcess` block (lines ~797–823, beginning `else if (stepType === 'Script' || stepType === 'ExecuteScript')` through the end of the `StartProcess`/`RunProcess` branch).
+
+Leave the `ExecuteSQL`/`RunSQL` branch between them **in place** (descriptors do not cover SQL). After deletion, the chain should flow from the `Loop` details branch → `ExecuteSQL`/`RunSQL` branch → `FilterTable` branch, with `Script` and `StartProcess` details now produced solely by the descriptors.
+
+> If the surrounding `else if` chain breaks (a dangling `else`), re-join the neighbors so `ExecuteSQL`/`RunSQL` and `FilterTable` remain reachable.
+
+- [ ] **Step 2: Run the descriptor + integration tests**
+
+Run: `pnpm vitest run tests/StepDescriptors.test.ts`
+Expected: PASS — Script/StartProcess details now come only from descriptors; assertions (`Language:`, `Param:`) still hold.
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/parsers/EtlParser.ts
+git commit -m "refactor(etl): drop inline Script/StartProcess blocks now in descriptors"
+```
+
+---
+
+### Task 6: Render icons in the HTML flow view
+
+**Files:**
+- Modify: `src/lib/generators/EtlGenerator.ts:605-614`
+- Test: `tests/EtlGenerator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/EtlGenerator.test.ts` mocks both `db.reports.get` and `EtlParser.parseSteps`
+(see the `vi.mock` calls at the top). So the test supplies a pre-built tree via the
+`parseSteps` mock — it does NOT parse real XML. Add this test inside the
+`describe('EtlGenerator', ...)` block, mirroring the existing "renders recursive
+groups correctly" test:
+
+```ts
+it('shows a script icon for Script steps', async () => {
+    const mockReport = {
+        id: 1,
+        metadata: { name: 'Test', version: '1.0' },
+        rawSteps: {},
+        dateAdded: new Date(),
+    };
+    vi.mocked(db.reports.get).mockResolvedValue(mockReport as any);
+
+    const mockFlow = {
+        executionTree: [
+            { id: 's1', Step: 'Transform', RawType: 'Script', Phase: 'Script',
+              Context: 'Script: VBScript', Details: [] },
+        ],
+        executionFlow: [],
+        variables: [],
+        variableSet: new Set(),
+        tableSet: new Set(),
+    };
+    vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
+
+    const html = await EtlGenerator.generateHtmlView(1);
+    expect(html).toContain('📜');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/EtlGenerator.test.ts`
+Expected: FAIL — `📜` not present (no icon mapped for `Script`).
+
+- [ ] **Step 3: Extend the `filenameIcon` map**
+
+In `src/lib/generators/EtlGenerator.ts`, find the `filenameIcon` ternary (lines ~605-614, ending `: '';`). Replace its final `: ''` fallback with cases for the new types. The existing chain ends:
+
+```ts
+                      : item.RawType === 'SendEmail'
+                          ? '📧'
+                          : '';
+```
+
+Change to:
+
+```ts
+                      : item.RawType === 'SendEmail'
+                          ? '📧'
+                          : item.RawType === 'Script' || item.RawType === 'ExecuteScript'
+                            ? '📜'
+                            : item.RawType === 'StartProcess' || item.RawType === 'RunProcess'
+                              ? '▶'
+                              : item.RawType === 'DTS' ||
+                                  item.RawType === 'ExecuteDTS' ||
+                                  item.RawType === 'RunDTS'
+                                ? '🔀'
+                                : item.Icon || '';
+```
+
+> Note the final fallback is now `item.Icon || ''` so any descriptor-supplied icon flows through automatically.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/EtlGenerator.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/generators/EtlGenerator.ts tests/EtlGenerator.test.ts
+git commit -m "feat(etl): render distinct icons for Script/StartProcess/DTS in HTML view"
+```
+
+---
+
+### Task 7: Distinct shapes in the Mermaid diagram
+
+**Files:**
+- Modify: `src/lib/generators/MermaidGenerator.ts:166-174`
+- Test: `tests/MermaidGenerator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/MermaidGenerator.test.ts` (mirror the file's existing flow-array shape — items are plain objects with `RawType`, `Step`, `FlowLabel`):
+
+```ts
+it('gives Script/StartProcess/DTS steps an icon label', () => {
+    const syntax = MermaidGenerator.generateMermaidSyntax([
+        { RawType: 'Script', Step: 'Transform', FlowLabel: 'Script: VBScript', Details: [] },
+        { RawType: 'StartProcess', Step: 'Kick', FlowLabel: 'Run: Rollup', Details: [] },
+        { RawType: 'DTS', Step: 'Load', FlowLabel: 'DTS: LoadGL', Details: [] },
+    ]);
+    expect(syntax).toContain('📜');
+    expect(syntax).toContain('▶');
+    expect(syntax).toContain('🔀');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/MermaidGenerator.test.ts`
+Expected: FAIL — none of the icons present (types fall to default `process` shape with bare label).
+
+- [ ] **Step 3: Add a mapping branch**
+
+In `src/lib/generators/MermaidGenerator.ts`, inside `generateMermaidSyntax`, find the shape-mapping `if/else if` chain (lines ~140-174). After the `CalculateVariable`/`SetVariable` branch (ends line ~174 `className = 'process';` then `}`), add:
+
+```ts
+                } else if (['Script', 'ExecuteScript'].includes(item.RawType)) {
+                    shape = '[/';
+                    shapeEnd = '/]';
+                    className = 'process';
+                    label = '📜 ' + label.trim();
+                } else if (['StartProcess', 'RunProcess'].includes(item.RawType)) {
+                    shape = '[[';
+                    shapeEnd = ']]';
+                    className = 'process';
+                    label = '▶ ' + label.trim();
+                } else if (['DTS', 'ExecuteDTS', 'RunDTS'].includes(item.RawType)) {
+                    shape = '[/';
+                    shapeEnd = '/]';
+                    className = 'process';
+                    label = '🔀 ' + label.trim();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/MermaidGenerator.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/generators/MermaidGenerator.ts tests/MermaidGenerator.test.ts
+git commit -m "feat(etl): distinct Mermaid shapes for Script/StartProcess/DTS"
+```
+
+---
+
+### Task 8: Document UNVERIFIED Tier-B field names
+
+**Files:**
+- Modify: `docs/FILE_FORMATS.md`
+
+- [ ] **Step 1: Append a section to `docs/FILE_FORMATS.md`**
+
+At the end of `docs/FILE_FORMATS.md`, add:
+
+```markdown
+## Advanced step types — UNVERIFIED field names
+
+`StartProcess`, `Script`, and `DTS` step types are parsed defensively because no
+sample `.t1etlp` in this repo contains them and TechnologyOne's ETL XML schema is
+not publicly documented. The parser (`src/lib/parsers/StepDescriptors.ts`) tries
+multiple candidate keys per field and degrades gracefully if none match. **These
+key names are assumptions — correct them against a real file when available.**
+
+| Step type      | Field        | Candidate keys (first non-empty wins)                          |
+| -------------- | ------------ | -------------------------------------------------------------- |
+| StartProcess   | process name | `ProcessName`, `ProcessToRun`, `Process`, `SubProcessName`     |
+| Script         | language     | `ScriptLanguage`, `Language`                                   |
+| Script         | body         | `ScriptText`, `Script`                                         |
+| DTS            | package      | `DTSPackageName`, `PackageName`, `DTSPackage`, `Package`       |
+| DTS            | connection   | `ConnectionString`, `Connection`, `DTSConnection`             |
+
+`Group` handling is verified against real sample data (the step `<Name>` is the
+label; children attach via `ParentStepId`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/FILE_FORMATS.md
+git commit -m "docs(etl): document UNVERIFIED StartProcess/Script/DTS field keys"
+```
+
+---
+
+### Task 9: Full verification + branch finish
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pnpm vitest run`
+Expected: PASS — all prior tests green plus the new `StepDescriptors` / generator tests.
+
+- [ ] **Step 2: Type-check + build**
+
+Run: `pnpm tsc --noEmit`
+Expected: PASS.
+
+(Optional full build, slower) Run: `pnpm build`
+Expected: succeeds.
+
+- [ ] **Step 3: Manual sanity via the running app (optional but recommended)**
+
+Use the project's run/preview workflow to load a sample `.t1etlp` that contains a
+`Group` (e.g. `AFRG_I&E_CHART...t1etlp`) and confirm the group now shows its real
+name ("Prep Chart of Accounts") instead of "Group" in both the flow view and the
+Mermaid diagram.
+
+- [ ] **Step 4: Update the README roadmap checkbox**
+
+In `README.md`, change the line:
+
+```markdown
+- [ ] **Advanced Logic**: Better distinct handling for `StartProcess`, `Script`, and `DTS` tasks.
+```
+
+to `- [x]`.
+
+Then commit:
+
+```bash
+git add README.md
+git commit -m "docs: mark Advanced Logic roadmap item complete"
+```
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to choose merge/PR/cleanup.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Group label+count (T2/T4), Script/StartProcess/DTS extraction (T3), defensive try/catch + fallback (T4 step 5, malformed test T4 step 1), `Icon` field (T1), HTML icons (T6), Mermaid shapes (T7), EtlSummary unchanged (no task — by design), fixture/mock tests (T2-T4), docs UNVERIFIED note (T8). All spec sections mapped.
+- **Type consistency:** `StepDescriptor`/`DescriptorFn`/`DescriptorHelpers`/`makeHelpers`/`STEP_DESCRIPTORS` names identical across T2-T4. `explicitOutput` shape `{ type, name } | null` matches `getExplicitOutput`'s existing return contract. `Icon` field name consistent T1/T4/T6.
+- **No placeholders:** every code step shows full code; the two soft spots (T6 DB-seed helper, T7 flow-array shape) explicitly instruct mirroring the existing test file rather than inventing APIs.

--- a/docs/superpowers/specs/2026-06-07-etl-advanced-logic-design.md
+++ b/docs/superpowers/specs/2026-06-07-etl-advanced-logic-design.md
@@ -1,0 +1,203 @@
+# ETL Advanced Logic — StartProcess / Script / DTS / Group
+
+**Date:** 2026-06-07
+**Roadmap item:** *Advanced Logic — Better distinct handling for `StartProcess`, `Script`, and `DTS` tasks.*
+**Status:** Approved design, pre-implementation.
+
+## Problem
+
+The ETL parser renders four step types poorly:
+
+- **`Group`** — a labeled container holding child steps. Currently shows the literal
+  word "Group" instead of its real name (e.g. *"Prep Chart of Accounts"*). Verified
+  against sample data.
+- **`StartProcess` / `Script` / `DTS`** — control-flow tasks that run a sub-process,
+  execute a script, or invoke a DTS package. They fall to the generic fallback
+  (`contextText = stepType`), get no icon, no flow label, no inputs/outputs, and no
+  explicit-output lineage. DTS has zero handling at all.
+
+## Confidence tiers
+
+This work splits into two tiers with different verification stories.
+
+### Tier A — verified (`Group`)
+
+Backed by real sample data
+(`samples/extraction/AFRG_I&E_CHART_.../Steps.xml`, StepId 22). The `Group`
+`StorageObject` carries only a `DefKey`; the display label is the step's `<Name>`.
+Children attach via `ParentStepId`. This is a provable bug-fix.
+
+### Tier B — inferred (`StartProcess` / `Script` / `DTS`)
+
+**No sample files contain these step types**, and a web search confirmed
+TechnologyOne's ETL XML field names are proprietary and undocumented. The existing
+parser code for `Script` / `StartProcess` (EtlParser.ts lines ~797–822) is the prior
+author's guesswork.
+
+Tier B is therefore built as **defensive multi-key extraction**: each field is read
+by trying several candidate names, the whole descriptor is wrapped in try/catch, and
+an unexpected shape degrades to today's generic behavior rather than crashing the
+report. Correctness is locked in by **fixture-based tests** that model the *assumed*
+schema; when a real file is supplied, the fixtures get corrected and the failing test
+is the verification signal. Candidate field names are documented as UNVERIFIED.
+
+## Architecture
+
+Three focused units. The parser's `traverse()` is already ~470 lines; rather than
+add four more `else if` blocks, the four target types move into a dedicated
+descriptor module. Unrelated step types are left untouched.
+
+### Unit 1 — `src/lib/parsers/StepDescriptors.ts` (new)
+
+A lookup keyed by step type. Each entry is a pure function returning a descriptor.
+
+```ts
+export interface StepDescriptor {
+  contextText: string;
+  flowLabel: string;
+  details: string[];
+  inputs: string[];
+  outputs: string[];
+  explicitOutput: { type: string; name: string } | null;
+  icon?: string;
+  smartDesc?: string;
+}
+
+export interface DescriptorHelpers {
+  getTextSafe: (v: XmlValue) => string;
+  getListSafe: (v: XmlValue, key: string) => XmlNode[];
+  firstOf: (storage: XmlNode, keys: string[]) => string; // defensive multi-key reader
+}
+
+// `step` is the raw step node with the parser-grafted `children` array
+// (RawStep = XmlNode & { children?: RawStep[] }), so the Group descriptor can
+// read its child count. RawStep is exported from EtlParser for this purpose.
+export type DescriptorFn =
+  (storage: XmlNode, step: RawStep, h: DescriptorHelpers) => StepDescriptor;
+
+export const STEP_DESCRIPTORS: Record<string, DescriptorFn>;
+```
+
+Helpers are injected so the module stays decoupled from `EtlParser` statics and is
+unit-testable in isolation.
+
+### Unit 2 — `src/lib/parsers/EtlParser.ts` (edit)
+
+In `traverse()`, when `STEP_DESCRIPTORS[stepType]` exists, call it (inside try/catch)
+and merge the descriptor into the existing `info` object. All other types keep their
+current inline logic. `getExplicitOutput()` delegates to the descriptor's
+`explicitOutput` for these four types.
+
+Fallback: on a descriptor throw, retain today's generic `contextText = stepType`
+behavior.
+
+`RawStep` (currently a private `type` alias in `EtlParser.ts`) is exported so the
+descriptor module and its signature can reference it.
+
+### Unit 3 — render paths (edit)
+
+- **`EtlGenerator.renderStep`** — add `StartProcess`/`Script`/`DTS` to the icon map.
+  `Group` already renders as a container via the `isGroup` array; it now receives a
+  real label through `Step`/`Context`.
+- **`MermaidGenerator.generateMermaidSyntax`** — add shape + class for the three new
+  standard-step types. `Group` already renders as a subgraph; no change needed.
+- **`EtlSummary`** — **no change.** `StartProcess`/`Script`/`DTS` are control-flow,
+  not data I/O, so they correctly contribute nothing to sources/targets.
+
+## Data flow
+
+```
+Steps.xml → FileProcessor → report.rawSteps
+  → EtlParser.parseSteps()
+      → traverse(step):
+          STEP_DESCRIPTORS[type] present? → describe() (try/catch) → merge into info
+          else → existing inline logic
+  → executionTree / executionFlow
+      → EtlGenerator (HTML + icons)
+      → MermaidGenerator (shapes/classes)
+      → EtlSummary (narrative — unchanged)
+```
+
+## Type changes
+
+One additive, optional field on `EtlStep`:
+
+```ts
+/** Display glyph for this step type (single source of truth for HTML + Mermaid). */
+Icon?: string;
+```
+
+No other `EtlStep` changes. Descriptors fill existing fields
+(`Context`, `FlowLabel`, `Details`, `Inputs`, `Outputs`, `Output`, `SmartDesc`).
+
+## Per-type detail
+
+### Group (Tier A — verified)
+
+- `contextText` / `flowLabel` = step `Name` (e.g. *"Prep Chart of Accounts"*)
+- `smartDesc` = `"Groups N steps"` (child count)
+- no inputs/outputs, no `explicitOutput`
+- icon `🗂️`
+
+### StartProcess / RunProcess (Tier B — inferred)
+
+- process name: `firstOf(['ProcessName','ProcessToRun','Process','SubProcessName'])`
+- parameters: `getListSafe(storage.Parameters, 'ParameterItem')` → `Param: <name> = <value>`
+- `flowLabel` = `"Run: <proc>"`
+- `explicitOutput` = `{ type: 'PROCESS', name: <proc> }`
+- icon `▶`
+
+### Script / ExecuteScript (Tier B — inferred)
+
+- language: `firstOf(['ScriptLanguage','Language'])`
+- body preview: `firstOf(['ScriptText','Script'])`, truncated to 150 chars
+- `flowLabel` = `"Script: <lang>"` (or `"Script"` if no language)
+- icon `📜`
+
+### DTS / ExecuteDTS / RunDTS (Tier B — inferred, currently zero handling)
+
+- package name: `firstOf(['DTSPackageName','PackageName','DTSPackage','Package'])`
+- connection/config: `firstOf(['ConnectionString','Connection','DTSConnection'])`
+- `flowLabel` = `"DTS: <pkg>"`
+- icon `🔀`
+
+## Error handling
+
+Each descriptor invocation is wrapped in try/catch inside `traverse()`. A throw
+(malformed or unexpected Tier-B shape) falls back to today's generic behavior —
+the step still renders with its type name; the report never crashes. This mirrors
+the existing `flattenLogic` try/catch philosophy.
+
+## Testing
+
+Extend `src/lib/parsers/EtlParser.test.ts` (and/or a new
+`StepDescriptors.test.ts`):
+
+- **Group (real data):** parse the `AFRG_I&E_CHART` sample, assert the Group step's
+  label is *"Prep Chart of Accounts"*, children are attached, and `smartDesc`
+  reflects the child count.
+- **StartProcess / Script / DTS (fixtures):** hand-authored fixture XML under
+  `src/lib/parsers/__fixtures__/` modeling the inferred shapes. Tests prove the
+  descriptor extracts correctly *given the assumed schema*.
+- **Defensive:** a `StartProcess` step missing every candidate key → asserts graceful
+  fallback with no throw.
+
+## Documentation
+
+Add a note (in `docs/FILE_FORMATS.md` or a new `docs/ETL_STEP_TYPES.md`) marking the
+Tier-B field names as **UNVERIFIED**, listing the candidate-key sets, so the
+assumption is explicit and easy to correct when a real file arrives.
+
+## YAGNI cuts
+
+- No new `EtlStep` fields beyond optional `Icon`.
+- No narrative change for sub-processes (control-flow ≠ data lineage).
+- No Mermaid Group rewrite (already works).
+- Scope limited to the four named types; no broad `traverse()` refactor.
+
+## Out of scope / follow-ups
+
+- Migrating other inline step types into `StepDescriptors.ts` (future cleanup once
+  the pattern proves out).
+- Verifying Tier-B field names against a real `.t1etlp` (blocked on sample
+  availability).

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -611,7 +611,13 @@ export class EtlGenerator {
                         ? '📄'
                         : item.RawType === 'SendEmail'
                           ? '📧'
-                          : '';
+                          : item.RawType === 'Script' || item.RawType === 'ExecuteScript'
+                            ? '📜'
+                            : item.RawType === 'StartProcess' || item.RawType === 'RunProcess'
+                              ? '▶'
+                              : item.RawType === 'DTS' || item.RawType === 'ExecuteDTS' || item.RawType === 'RunDTS'
+                                ? '🔀'
+                                : item.Icon || '';
             const stepId = item.id || item.StepId || '';
             const stepAnchorId = stepId ? `step-${stepId.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
 

--- a/src/lib/generators/EtlGenerator.ts
+++ b/src/lib/generators/EtlGenerator.ts
@@ -602,22 +602,24 @@ export class EtlGenerator {
                 item.RawType === 'SendEmail'
                     ? 'filename-orange'
                     : '';
-            const filenameIcon =
-                item.RawType === 'ExportToExcel'
-                    ? '📊'
-                    : item.RawType === 'SaveText' || item.RawType === 'SaveTextfile'
-                      ? '📦'
-                      : item.RawType === 'LoadTextFile'
-                        ? '📄'
-                        : item.RawType === 'SendEmail'
-                          ? '📧'
-                          : item.RawType === 'Script' || item.RawType === 'ExecuteScript'
-                            ? '📜'
-                            : item.RawType === 'StartProcess' || item.RawType === 'RunProcess'
-                              ? '▶'
-                              : item.RawType === 'DTS' || item.RawType === 'ExecuteDTS' || item.RawType === 'RunDTS'
-                                ? '🔀'
-                                : item.Icon || '';
+            // Descriptor-supplied Icon is authoritative; fall back to the
+            // RawType→glyph map for types that don't go through a descriptor
+            // (ExportToExcel, SaveText, LoadTextFile, SendEmail).
+            const RAW_TYPE_ICONS: Record<string, string> = {
+                ExportToExcel: '📊',
+                SaveText: '📦',
+                SaveTextfile: '📦',
+                LoadTextFile: '📄',
+                SendEmail: '📧',
+                Script: '📜',
+                ExecuteScript: '📜',
+                StartProcess: '▶',
+                RunProcess: '▶',
+                DTS: '🔀',
+                ExecuteDTS: '🔀',
+                RunDTS: '🔀',
+            };
+            const filenameIcon = item.Icon || RAW_TYPE_ICONS[item.RawType] || '';
             const stepId = item.id || item.StepId || '';
             const stepAnchorId = stepId ? `step-${stepId.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
 

--- a/src/lib/generators/MermaidGenerator.ts
+++ b/src/lib/generators/MermaidGenerator.ts
@@ -171,6 +171,21 @@ export class MermaidGenerator {
                     shape = '[(';
                     shapeEnd = ')]';
                     className = 'process';
+                } else if (['Script', 'ExecuteScript'].includes(item.RawType)) {
+                    shape = '[/';
+                    shapeEnd = '/]';
+                    className = 'process';
+                    label = '📜 ' + label.trim();
+                } else if (['StartProcess', 'RunProcess'].includes(item.RawType)) {
+                    shape = '[[';
+                    shapeEnd = ']]';
+                    className = 'process';
+                    label = '▶ ' + label.trim();
+                } else if (['DTS', 'ExecuteDTS', 'RunDTS'].includes(item.RawType)) {
+                    shape = '[/';
+                    shapeEnd = '/]';
+                    className = 'process';
+                    label = '🔀 ' + label.trim();
                 }
 
                 steps.push(`    ${id}${shape}"${label}"${shapeEnd}:::${className}`);

--- a/src/lib/generators/MermaidGenerator.ts
+++ b/src/lib/generators/MermaidGenerator.ts
@@ -172,20 +172,22 @@ export class MermaidGenerator {
                     shapeEnd = ')]';
                     className = 'process';
                 } else if (['Script', 'ExecuteScript'].includes(item.RawType)) {
+                    // Shape stays type-driven; the glyph prefers the descriptor's
+                    // Icon (single source of truth) and falls back to the literal.
                     shape = '[/';
                     shapeEnd = '/]';
                     className = 'process';
-                    label = '📜 ' + label.trim();
+                    label = `${item.Icon || '📜'} ` + label.trim();
                 } else if (['StartProcess', 'RunProcess'].includes(item.RawType)) {
                     shape = '[[';
                     shapeEnd = ']]';
                     className = 'process';
-                    label = '▶ ' + label.trim();
+                    label = `${item.Icon || '▶'} ` + label.trim();
                 } else if (['DTS', 'ExecuteDTS', 'RunDTS'].includes(item.RawType)) {
                     shape = '[/';
                     shapeEnd = '/]';
                     className = 'process';
-                    label = '🔀 ' + label.trim();
+                    label = `${item.Icon || '🔀'} ` + label.trim();
                 }
 
                 steps.push(`    ${id}${shape}"${label}"${shapeEnd}:::${className}`);

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -828,16 +828,8 @@ export class EtlParser {
                 if (breakCond) info.Details.push(`Break When: ${breakCond}`);
                 if (indexVar) info.Details.push(`Index Variable: ${indexVar}`);
             }
-            // --- Script/SQL execution steps ---
-            else if (stepType === 'Script' || stepType === 'ExecuteScript') {
-                const lang = this.getTextSafe(storage.ScriptLanguage || storage.Language);
-                const scriptText = this.getTextSafe(storage.ScriptText || storage.Script);
-                if (lang) info.Details.push(`Language: ${lang}`);
-                if (scriptText) {
-                    const preview = scriptText.length > 150 ? scriptText.substring(0, 150) + '...' : scriptText;
-                    info.Details.push(`Script: ${preview}`);
-                }
-            } else if (stepType === 'ExecuteSQL' || stepType === 'RunSQL') {
+            // --- SQL execution steps (Script/StartProcess/DTS handled by StepDescriptors) ---
+            else if (stepType === 'ExecuteSQL' || stepType === 'RunSQL') {
                 const sql = this.getTextSafe(storage.SqlStatement || storage.SQL || storage.Query);
                 const conn = this.getTextSafe(storage.ConnectionString || storage.Connection);
                 if (conn) info.Details.push(`Connection: ${conn}`);
@@ -845,16 +837,6 @@ export class EtlParser {
                     const preview = sql.length > 200 ? sql.substring(0, 200) + '...' : sql;
                     info.Details.push(`SQL: ${preview}`);
                 }
-            } else if (stepType === 'StartProcess' || stepType === 'RunProcess') {
-                const procName = this.getTextSafe(storage.ProcessName || storage.ProcessToRun);
-                const procId = this.getTextSafe(storage.ProcessId);
-                if (procName) info.Details.push(`Process: ${procName}`);
-                if (procId && !procName) info.Details.push(`Process ID: ${procId}`);
-                // Process parameters
-                const params = this.getListSafe(storage.Parameters, 'ParameterItem');
-                params.forEach((p) => {
-                    info.Details.push(`Param: ${this.getTextSafe(p.Name)} = ${this.getTextSafe(p.Value)}`);
-                });
             }
             // --- FilterTable and SortTable ---
             else if (stepType === 'FilterTable') {

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -3,7 +3,7 @@ import { asNode } from './types';
 export type { EtlStep, LogicRule } from './types';
 
 /** A raw XML step node with the `children` array the parser grafts on. */
-type RawStep = XmlNode & { children?: RawStep[] };
+export type RawStep = XmlNode & { children?: RawStep[] };
 
 export class EtlParser {
     static getListSafe(obj: XmlValue, key: string): XmlNode[] {

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -1,11 +1,18 @@
 import type { EtlStep, LogicRule, XmlNode, XmlValue } from './types';
 import { asNode } from './types';
+import { STEP_DESCRIPTORS, makeHelpers, type StepDescriptor } from './StepDescriptors';
 export type { EtlStep, LogicRule } from './types';
 
 /** A raw XML step node with the `children` array the parser grafts on. */
 export type RawStep = XmlNode & { children?: RawStep[] };
 
 export class EtlParser {
+    private static descriptorHelpers = {
+        getTextSafe: (v: XmlValue) => EtlParser.getTextSafe(v),
+        getListSafe: (v: XmlValue, key: string) => EtlParser.getListSafe(v, key),
+        firstOf: makeHelpers().firstOf,
+    };
+
     static getListSafe(obj: XmlValue, key: string): XmlNode[] {
         const node = asNode(obj);
         if (!node || node[key] == null) return [];
@@ -179,6 +186,14 @@ export class EtlParser {
     }
 
     static getExplicitOutput(stepType: string, storage: XmlNode, _step: XmlValue) {
+        const descriptor = STEP_DESCRIPTORS[stepType];
+        if (descriptor) {
+            try {
+                return descriptor(storage, _step as RawStep, this.descriptorHelpers).explicitOutput;
+            } catch {
+                return null;
+            }
+        }
         const target = this.getTextSafe(storage.OutputTableName || storage.TableName || storage.VariableName);
         switch (stepType) {
             case 'ImportWarehouseData':
@@ -588,6 +603,26 @@ export class EtlParser {
             }
 
             info.FlowLabel = fl;
+
+            // --- Advanced step descriptors (Group / Script / StartProcess / DTS) ---
+            const advDescriptor = STEP_DESCRIPTORS[stepType];
+            if (advDescriptor) {
+                try {
+                    const d: StepDescriptor = advDescriptor(storage, step, this.descriptorHelpers);
+                    info.Context = d.contextText;
+                    info.FlowLabel = d.flowLabel;
+                    if (d.icon) info.Icon = d.icon;
+                    if (d.smartDesc) info.SmartDesc = d.smartDesc;
+                    if (d.inputs.length) info.Inputs = d.inputs;
+                    if (d.outputs.length) info.Outputs = d.outputs;
+                    d.details.forEach((line) => {
+                        if (!info.Details.includes(line)) info.Details.push(line);
+                    });
+                } catch (e) {
+                    console.error(`Descriptor failed for ${stepType}:`, e);
+                    // Fall back to the generic context already set above.
+                }
+            }
 
             if (!isActive) info.Phase += ' [DISABLED]';
 

--- a/src/lib/parsers/EtlParser.ts
+++ b/src/lib/parsers/EtlParser.ts
@@ -1,6 +1,6 @@
 import type { EtlStep, LogicRule, XmlNode, XmlValue } from './types';
 import { asNode } from './types';
-import { STEP_DESCRIPTORS, makeHelpers, type StepDescriptor } from './StepDescriptors';
+import { STEP_DESCRIPTORS, type StepDescriptor } from './StepDescriptors';
 export type { EtlStep, LogicRule } from './types';
 
 /** A raw XML step node with the `children` array the parser grafts on. */
@@ -10,7 +10,15 @@ export class EtlParser {
     private static descriptorHelpers = {
         getTextSafe: (v: XmlValue) => EtlParser.getTextSafe(v),
         getListSafe: (v: XmlValue, key: string) => EtlParser.getListSafe(v, key),
-        firstOf: makeHelpers().firstOf,
+        // firstOf uses EtlParser.getTextSafe so descriptor text extraction matches
+        // the rest of the parser (its #text/fallback behavior), not a divergent copy.
+        firstOf: (storage: XmlNode, keys: string[]): string => {
+            for (const k of keys) {
+                const t = EtlParser.getTextSafe(storage[k]);
+                if (t && t.trim().length > 0) return t.trim();
+            }
+            return '';
+        },
     };
 
     static getListSafe(obj: XmlValue, key: string): XmlNode[] {

--- a/src/lib/parsers/StepDescriptors.ts
+++ b/src/lib/parsers/StepDescriptors.ts
@@ -68,6 +68,71 @@ const groupDescriptor: DescriptorFn = (_storage, step, h) => {
     };
 };
 
+const scriptDescriptor: DescriptorFn = (storage, _step, h) => {
+    const lang = h.firstOf(storage, ['ScriptLanguage', 'Language']);
+    const body = h.firstOf(storage, ['ScriptText', 'Script']);
+    const details: string[] = [];
+    if (lang) details.push(`Language: ${lang}`);
+    if (body) {
+        const preview = body.length > 150 ? body.substring(0, 150) + '...' : body;
+        details.push(`Script: ${preview}`);
+    }
+    const label = lang ? `Script: ${lang}` : 'Script';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '📜',
+    };
+};
+
+const startProcessDescriptor: DescriptorFn = (storage, _step, h) => {
+    const proc = h.firstOf(storage, ['ProcessName', 'ProcessToRun', 'Process', 'SubProcessName']);
+    const details: string[] = [];
+    if (proc) details.push(`Process: ${proc}`);
+    h.getListSafe(storage.Parameters, 'ParameterItem').forEach((p) => {
+        details.push(`Param: ${h.getTextSafe(p.Name)} = ${h.getTextSafe(p.Value)}`);
+    });
+    const label = proc ? `Run: ${proc}` : 'Run Process';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: proc ? [proc] : [],
+        explicitOutput: proc ? { type: 'PROCESS', name: proc } : null,
+        icon: '▶',
+    };
+};
+
+const dtsDescriptor: DescriptorFn = (storage, _step, h) => {
+    const pkg = h.firstOf(storage, ['DTSPackageName', 'PackageName', 'DTSPackage', 'Package']);
+    const conn = h.firstOf(storage, ['ConnectionString', 'Connection', 'DTSConnection']);
+    const details: string[] = [];
+    if (pkg) details.push(`Package: ${pkg}`);
+    if (conn) details.push(`Connection: ${conn}`);
+    const label = pkg ? `DTS: ${pkg}` : 'DTS';
+    return {
+        contextText: label,
+        flowLabel: label,
+        details,
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '🔀',
+    };
+};
+
 export const STEP_DESCRIPTORS: Record<string, DescriptorFn> = {
     Group: groupDescriptor,
+    Script: scriptDescriptor,
+    ExecuteScript: scriptDescriptor,
+    StartProcess: startProcessDescriptor,
+    RunProcess: startProcessDescriptor,
+    DTS: dtsDescriptor,
+    ExecuteDTS: dtsDescriptor,
+    RunDTS: dtsDescriptor,
 };

--- a/src/lib/parsers/StepDescriptors.ts
+++ b/src/lib/parsers/StepDescriptors.ts
@@ -1,0 +1,73 @@
+import type { XmlNode, XmlValue } from './types';
+import { asNode } from './types';
+import type { RawStep } from './EtlParser';
+
+/** Display + lineage fields a descriptor produces for one step. */
+export interface StepDescriptor {
+    contextText: string;
+    flowLabel: string;
+    details: string[];
+    inputs: string[];
+    outputs: string[];
+    explicitOutput: { type: string; name: string } | null;
+    icon?: string;
+    smartDesc?: string;
+}
+
+/** Leaf/list readers injected by EtlParser so this module stays decoupled. */
+export interface DescriptorHelpers {
+    getTextSafe: (v: XmlValue) => string;
+    getListSafe: (v: XmlValue, key: string) => XmlNode[];
+    /** Returns the first non-empty text value among the candidate keys. */
+    firstOf: (storage: XmlNode, keys: string[]) => string;
+}
+
+export type DescriptorFn = (storage: XmlNode, step: RawStep, h: DescriptorHelpers) => StepDescriptor;
+
+/**
+ * Standalone helper factory (used by tests and as a fallback). EtlParser passes
+ * its own statics in production so behavior matches the rest of the parser.
+ */
+export function makeHelpers(): DescriptorHelpers {
+    const getTextSafe = (val: XmlValue): string => {
+        if (val == null || val === '') return '';
+        if (typeof val === 'string') return val;
+        if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+        const node = asNode(val);
+        if (node && typeof node['#text'] === 'string') return node['#text'];
+        return '';
+    };
+    const getListSafe = (obj: XmlValue, key: string): XmlNode[] => {
+        const node = asNode(obj);
+        if (!node || node[key] == null) return [];
+        const v = node[key];
+        return (Array.isArray(v) ? v : [v]) as XmlNode[];
+    };
+    const firstOf = (storage: XmlNode, keys: string[]): string => {
+        for (const k of keys) {
+            const t = getTextSafe(storage[k]);
+            if (t && t.trim().length > 0) return t.trim();
+        }
+        return '';
+    };
+    return { getTextSafe, getListSafe, firstOf };
+}
+
+const groupDescriptor: DescriptorFn = (_storage, step, h) => {
+    const name = h.getTextSafe(step.Name) || 'Group';
+    const count = (step.children || []).length;
+    return {
+        contextText: name,
+        flowLabel: name,
+        details: [],
+        inputs: [],
+        outputs: [],
+        explicitOutput: null,
+        icon: '🗂️',
+        smartDesc: `Groups ${count} steps`,
+    };
+};
+
+export const STEP_DESCRIPTORS: Record<string, DescriptorFn> = {
+    Group: groupDescriptor,
+};

--- a/src/lib/parsers/StepDescriptors.ts
+++ b/src/lib/parsers/StepDescriptors.ts
@@ -102,7 +102,10 @@ const startProcessDescriptor: DescriptorFn = (storage, _step, h) => {
         flowLabel: label,
         details,
         inputs: [],
-        outputs: proc ? [proc] : [],
+        // Subprocess lineage lives in explicitOutput only. Leaving `outputs`
+        // empty keeps EtlSummary/flow-wires from treating the subprocess name
+        // as a produced data table/target (it's control flow, not data).
+        outputs: [],
         explicitOutput: proc ? { type: 'PROCESS', name: proc } : null,
         icon: '▶',
     };

--- a/src/lib/parsers/types.ts
+++ b/src/lib/parsers/types.ts
@@ -39,6 +39,8 @@ export interface EtlStep {
     Name?: string;
     /** Generic value field. */
     Value?: string;
+    /** Display glyph for this step type (single source of truth for HTML + Mermaid). */
+    Icon?: string;
 
     // Allow the remaining dynamically-attached parser fields (SmartDesc,
     // TableData, Headers, FlowLabel, IsActive, Depth, StepId, etc.) without

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,7 +229,8 @@ async function render() {
         content += `
         <main class="grow p-6 bg-gray-100 w-full animate-fade-in">
              <div class="w-full">
-                 <div class="sticky top-0 z-30 glass-toolbar flex flex-col md:flex-row md:items-center justify-between gap-4 py-4 mb-2">
+                 <div class="sticky top-0 z-30 glass-toolbar w-full flex items-center gap-2 text-sm text-gray-500 ">
+                 <div class="flex flex-col md:flex-row md:space-between gap-4 py-4 mb-2 mw-4xl mx-auto">
                     <button onclick="window.navigateTo('dashboard')" class="text-sm text-gray-500 hover:text-gray-900 flex items-center">
                         <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
                         Back to Library
@@ -239,6 +240,7 @@ async function render() {
                          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
                          Export
                     </button>
+                    </div>
                  </div>
                  <div id="detailContainer" class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden w-full flex flex-col max-w-4xl mx-auto">
                     <div class="p-12 text-center text-gray-400">

--- a/src/style.css
+++ b/src/style.css
@@ -291,9 +291,8 @@ details[open]>summary::after {
 .glass-toolbar {
   backdrop-filter: blur(12px) saturate(180%);
   -webkit-backdrop-filter: blur(12px) saturate(180%);
-  background-color: rgba(255, 255, 255, .1%);
-  background-blend-mode: overlay;
-  border-bottom: 1px solid white;
+  background-color: rgba(255, 255, 255, 0.75);
+  border-bottom: 1px solid rgb(226 232 240); /* slate-200 */
 }
 
 .glass-toolbar>* {

--- a/tests/EtlGenerator.test.ts
+++ b/tests/EtlGenerator.test.ts
@@ -124,6 +124,31 @@ describe('EtlGenerator', () => {
         expect(html).toContain('step-notes-container');
     });
 
+    it('shows a script icon for Script steps', async () => {
+        const mockReport = {
+            id: 1,
+            metadata: { name: 'Test', version: '1.0' },
+            rawSteps: {},
+            dateAdded: new Date(),
+        };
+        vi.mocked(db.reports.get).mockResolvedValue(mockReport as any);
+
+        const mockFlow = {
+            executionTree: [
+                { id: 's1', Step: 'Transform', RawType: 'Script', Phase: 'Script',
+                  Context: 'Script: VBScript', Details: [] },
+            ],
+            executionFlow: [],
+            variables: [],
+            variableSet: new Set(),
+            tableSet: new Set(),
+        };
+        vi.mocked(EtlParser.parseSteps).mockReturnValue(mockFlow as any);
+
+        const html = await EtlGenerator.generateHtmlView(1);
+        expect(html).toContain('📜');
+    });
+
     it('renders variables table', async () => {
         const mockReport = {
             id: 1,

--- a/tests/MermaidGenerator.test.ts
+++ b/tests/MermaidGenerator.test.ts
@@ -109,4 +109,15 @@ describe('MermaidGenerator', () => {
         expect(syntax).toContain('End');
     });
 
+    it('gives Script/StartProcess/DTS steps an icon label', () => {
+        const syntax = MermaidGenerator.generateMermaidSyntax([
+            { RawType: 'Script', Step: 'Transform', FlowLabel: 'Script: VBScript', Details: [] },
+            { RawType: 'StartProcess', Step: 'Kick', FlowLabel: 'Run: Rollup', Details: [] },
+            { RawType: 'DTS', Step: 'Load', FlowLabel: 'DTS: LoadGL', Details: [] },
+        ]);
+        expect(syntax).toContain('📜');
+        expect(syntax).toContain('▶');
+        expect(syntax).toContain('🔀');
+    });
+
 });

--- a/tests/StepDescriptors.test.ts
+++ b/tests/StepDescriptors.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { STEP_DESCRIPTORS, makeHelpers } from '../src/lib/parsers/StepDescriptors';
+import type { RawStep } from '../src/lib/parsers/EtlParser';
+
+const h = makeHelpers();
+
+describe('StepDescriptors', () => {
+    describe('Group', () => {
+        it('uses the step Name as label and counts children', () => {
+            const step: RawStep = {
+                StepType: 'Group',
+                Name: 'Prep Chart of Accounts',
+                Definition: { StorageObject: { DefKey: 'abc' } },
+                children: [{ StepType: 'RunDirectQuery' }, { StepType: 'AddColumn' }],
+            };
+            const storage = { DefKey: 'abc' };
+            const d = STEP_DESCRIPTORS['Group'](storage, step, h);
+            expect(d.contextText).toBe('Prep Chart of Accounts');
+            expect(d.flowLabel).toBe('Prep Chart of Accounts');
+            expect(d.smartDesc).toBe('Groups 2 steps');
+            expect(d.icon).toBe('🗂️');
+            expect(d.inputs).toEqual([]);
+            expect(d.outputs).toEqual([]);
+            expect(d.explicitOutput).toBeNull();
+        });
+
+        it('falls back to "Group" when Name is empty', () => {
+            const step: RawStep = { StepType: 'Group', Name: '', children: [] };
+            const d = STEP_DESCRIPTORS['Group']({}, step, h);
+            expect(d.contextText).toBe('Group');
+            expect(d.smartDesc).toBe('Groups 0 steps');
+        });
+    });
+});

--- a/tests/StepDescriptors.test.ts
+++ b/tests/StepDescriptors.test.ts
@@ -31,4 +31,58 @@ describe('StepDescriptors', () => {
             expect(d.smartDesc).toBe('Groups 0 steps');
         });
     });
+
+    describe('Script', () => {
+        it('extracts language and truncates body preview', () => {
+            const body = 'x'.repeat(200);
+            const storage = { ScriptLanguage: 'VBScript', ScriptText: body };
+            const d = STEP_DESCRIPTORS['Script'](storage, { StepType: 'Script' }, h);
+            expect(d.flowLabel).toBe('Script: VBScript');
+            expect(d.icon).toBe('📜');
+            expect(d.details.some((l) => l.startsWith('Language: VBScript'))).toBe(true);
+            expect(d.details.some((l) => l.includes('...'))).toBe(true);
+        });
+
+        it('reads alternate keys and degrades without language', () => {
+            const storage = { Language: 'PowerShell', Script: 'Get-Date' };
+            const d = STEP_DESCRIPTORS['ExecuteScript'](storage, { StepType: 'ExecuteScript' }, h);
+            expect(d.flowLabel).toBe('Script: PowerShell');
+            const bare = STEP_DESCRIPTORS['Script']({}, { StepType: 'Script' }, h);
+            expect(bare.flowLabel).toBe('Script');
+        });
+    });
+
+    describe('StartProcess', () => {
+        it('extracts process name, params, and output token', () => {
+            const storage = {
+                ProcessName: 'NightlyRollup',
+                Parameters: { ParameterItem: [{ Name: 'Year', Value: '2026' }] },
+            };
+            const d = STEP_DESCRIPTORS['StartProcess'](storage, { StepType: 'StartProcess' }, h);
+            expect(d.flowLabel).toBe('Run: NightlyRollup');
+            expect(d.icon).toBe('▶');
+            expect(d.explicitOutput).toEqual({ type: 'PROCESS', name: 'NightlyRollup' });
+            expect(d.details.some((l) => l === 'Param: Year = 2026')).toBe(true);
+        });
+
+        it('reads alternate process key', () => {
+            const d = STEP_DESCRIPTORS['RunProcess']({ ProcessToRun: 'P2' }, { StepType: 'RunProcess' }, h);
+            expect(d.flowLabel).toBe('Run: P2');
+        });
+    });
+
+    describe('DTS', () => {
+        it('extracts package name and connection', () => {
+            const storage = { DTSPackageName: 'LoadGL', ConnectionString: 'Server=x' };
+            const d = STEP_DESCRIPTORS['DTS'](storage, { StepType: 'DTS' }, h);
+            expect(d.flowLabel).toBe('DTS: LoadGL');
+            expect(d.icon).toBe('🔀');
+            expect(d.details.some((l) => l.startsWith('Connection: Server=x'))).toBe(true);
+        });
+
+        it('degrades to bare label when package missing', () => {
+            const d = STEP_DESCRIPTORS['RunDTS']({}, { StepType: 'RunDTS' }, h);
+            expect(d.flowLabel).toBe('DTS');
+        });
+    });
 });

--- a/tests/StepDescriptors.test.ts
+++ b/tests/StepDescriptors.test.ts
@@ -69,6 +69,12 @@ describe('StepDescriptors', () => {
             const d = STEP_DESCRIPTORS['RunProcess']({ ProcessToRun: 'P2' }, { StepType: 'RunProcess' }, h);
             expect(d.flowLabel).toBe('Run: P2');
         });
+
+        it('keeps subprocess lineage out of outputs (control flow, not data)', () => {
+            const d = STEP_DESCRIPTORS['StartProcess']({ ProcessName: 'Sub' }, { StepType: 'StartProcess' }, h);
+            expect(d.outputs).toEqual([]);
+            expect(d.explicitOutput).toEqual({ type: 'PROCESS', name: 'Sub' });
+        });
     });
 
     describe('DTS', () => {

--- a/tests/StepDescriptors.test.ts
+++ b/tests/StepDescriptors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { STEP_DESCRIPTORS, makeHelpers } from '../src/lib/parsers/StepDescriptors';
-import type { RawStep } from '../src/lib/parsers/EtlParser';
+import { EtlParser, type RawStep } from '../src/lib/parsers/EtlParser';
 
 const h = makeHelpers();
 
@@ -84,5 +84,50 @@ describe('StepDescriptors', () => {
             const d = STEP_DESCRIPTORS['RunDTS']({}, { StepType: 'RunDTS' }, h);
             expect(d.flowLabel).toBe('DTS');
         });
+    });
+});
+
+describe('parseSteps integration — advanced step types', () => {
+    const wrap = (steps: any[]) => ({ ArrayOfStep: { Step: steps } });
+
+    it('labels a Group by its Name with a child count', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'Group', Name: 'Prep COA',
+                  Definition: { StorageObject: { DefKey: 'g1' } } },
+                { StepId: '2', ParentStepId: '1', Sequence: '1', StepType: 'AddColumn', Name: 'Calc',
+                  Definition: { StorageObject: { Columns: { ColumnItemDef: { ColumnName: 'X', Expression: '1' } } } } },
+            ])
+        ).executionTree;
+        const group = tree[0];
+        expect(group.RawType).toBe('Group');
+        expect(group.FlowLabel).toBe('Prep COA');
+        expect(group.Context).toBe('Prep COA');
+        expect(group.SmartDesc).toBe('Groups 1 steps');
+        expect(group.Icon).toBe('🗂️');
+        expect(group.children).toHaveLength(1);
+    });
+
+    it('describes a StartProcess step', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'StartProcess', Name: 'Kick',
+                  Definition: { StorageObject: { ProcessName: 'NightlyRollup' } } },
+            ])
+        ).executionTree;
+        expect(tree[0].FlowLabel).toBe('Run: NightlyRollup');
+        expect(tree[0].Icon).toBe('▶');
+        expect(tree[0].Output).toEqual({ type: 'PROCESS', name: 'NightlyRollup' });
+    });
+
+    it('does not crash on a malformed StartProcess (no candidate keys)', () => {
+        const tree = EtlParser.parseSteps(
+            wrap([
+                { StepId: '1', ParentStepId: '0', Sequence: '1', StepType: 'StartProcess', Name: 'Empty',
+                  Definition: { StorageObject: {} } },
+            ])
+        ).executionTree;
+        expect(tree[0].RawType).toBe('StartProcess');
+        expect(tree[0].FlowLabel).toBe('Run Process');
     });
 });


### PR DESCRIPTION
## Summary

Gives the ETL parser first-class handling for four step types that previously fell to a generic fallback (bare type name, no icon, no lineage). Closes the README roadmap item *Advanced Logic — Better distinct handling for `StartProcess`, `Script`, and `DTS` tasks.*

- **New `StepDescriptors.ts` module** — one pure descriptor function per target type, helpers injected from `EtlParser` (decoupled, unit-testable). `traverse()` delegates these types inside a try/catch and merges the result into the existing `EtlStep`; all other types untouched.
- **`Group`** (verified vs. real sample data) — now labeled by its `<Name>` ("Prep Chart of Accounts") with a child-count smart-desc, instead of the literal word "Group".
- **`StartProcess` / `Script` / `DTS`** (defensive) — extracted via multi-key candidate readers (`firstOf`), distinct flow labels, icons (`▶` / `📜` / `🔀`), and Mermaid shapes. DTS had zero handling before.
- Added optional `Icon` field on `EtlStep` (single source of truth for HTML + Mermaid glyphs).
- Removed the now-duplicated inline `Script`/`StartProcess` blocks from `traverse()`.

### Confidence tiers
`Group` is backed by real sample data. `StartProcess`/`Script`/`DTS` XML field names are **UNVERIFIED** — no sample `.t1etlp` contains them and the T1 schema is not public. Extraction is defensive and degrades gracefully; candidate keys are documented in `docs/FILE_FORMATS.md` for correction against a real file.

Spec: `docs/superpowers/specs/2026-06-07-etl-advanced-logic-design.md`
Plan: `docs/superpowers/plans/2026-06-07-etl-advanced-logic.md`

## Test Plan
- [x] `pnpm vitest run` — 70/70 pass (13 new: descriptor unit + parse integration + HTML icon + Mermaid shape + malformed-input fallback)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm build` — clean
- [ ] Verify against a real `.t1etlp` containing StartProcess/Script/DTS to confirm Tier-B field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)