### PR TITLE
chore(claude): add Claude Code automations

### DIFF
--- a/.claude/agents/bundle-guard.md
+++ b/.claude/agents/bundle-guard.md
@@ -1,0 +1,51 @@
+---
+name: bundle-guard
+description: Guards client bundle size for this browser-only app. Use after adding/changing imports or dependencies, before a PR. Flags heavy eager imports and verifies chunk-splitting/lazy-loading is preserved.
+tools: Glob, Grep, Read, Bash
+model: sonnet
+---
+
+# Bundle Guard
+
+This is a **client-only SPA** — every byte ships to the browser. Keeping the main entry small
+is an explicit project goal (mermaid was cut from eager 1.37MB to a 244KB lazy chunk). You
+guard against regressions when imports or dependencies change.
+
+## What to check
+
+### 1. Heavy libs must stay split / lazy
+`vite.config.ts` `manualChunks` splits `mermaid`, `docx`, `fast-xml-parser`+`jszip` into
+separate chunks. `mermaid` is additionally **lazy-loaded** (dynamic `import()` in
+`MermaidGenerator`) so it only downloads when a chart renders.
+
+- Confirm any new heavy dependency is added to `manualChunks` if it shouldn't be in the main entry.
+- Confirm `mermaid` is still imported via dynamic `import()`, NOT a top-level `import` — a
+  static import anywhere in the main graph defeats the lazy split.
+- `docx` should only load on export. Flag any top-level `docx` import reachable from `main.ts`'s
+  initial render path.
+
+### 2. New eager imports
+For changed/added imports in `src/`:
+- Is the imported package large? (check `node_modules/<pkg>/package.json` size hints, or known
+  heavyweights). Flag eager imports of anything chart/doc/parser-sized.
+- Prefer dynamic `import()` for anything only needed on a user action (export, render-on-click).
+
+### 3. Build measurement (optional, if asked or if uncertain)
+Run `pnpm build` and read the Vite output / `dist/assets/` sizes. Compare the main entry chunk
+against the mermaid/docx/xml chunks — the entry should stay well under the vendor chunks.
+Report the actual sizes.
+
+## How to review
+
+1. `grep` for `import` of `mermaid`, `docx`, `jszip`, `fast-xml-parser` across `src/` — verify
+   static vs dynamic per the rules above.
+2. Read `vite.config.ts` to confirm `manualChunks` still covers all heavy deps.
+3. Read `MermaidGenerator.ts` — confirm the dynamic import is intact.
+4. If a `package.json` dependency was added, assess its weight and where it loads.
+
+## Output
+
+- List any heavy **eager** imports on the initial path, with file:line + a lazy-load suggestion.
+- Note any heavy dep missing from `manualChunks`.
+- If you ran `pnpm build`, report entry vs vendor chunk sizes.
+- Verdict: `OK` or `N concerns`. Report only — do not modify files.

--- a/.claude/agents/xss-reviewer.md
+++ b/.claude/agents/xss-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: xss-reviewer
+description: Audits HTML-generating code for unescaped file-derived values (XSS). Use before opening a PR, or after editing any generator/formatter/main.ts. Reviews innerHTML/insertAdjacentHTML/template-string sinks for missing escapeHtml.
+tools: Glob, Grep, Read
+model: sonnet
+---
+
+# XSS Reviewer
+
+You audit this codebase for cross-site-scripting introduced when **file-derived text is
+interpolated into HTML strings without escaping**. This has regressed 3 times here (SmartDesc,
+`main.ts` itemRow, `EtlGenerator`). Your job: find every unescaped sink and report it.
+
+## Threat model
+
+The app parses untrusted `.t1etlp` / `.t1dm` XML and renders it as HTML via string
+concatenation. Any parsed value (step names, descriptions, expressions, table/column names,
+comments, raw types) is attacker-controlled text. If it reaches the DOM unescaped, it's XSS —
+even though the app is "local", a malicious sample file shared between users is a real vector.
+
+## The rule
+
+Every file-derived value placed into an HTML string MUST be one of:
+1. Passed through `ExpressionFormatter.escapeHtml()`, OR
+2. Passed through `ExpressionFormatter.colouriseTextHTML()` (escapes internally), OR
+3. A value the code itself produced from a fixed allowlist (e.g. a known icon name, a
+   numeric count, a hardcoded CSS class) — NOT raw file content.
+
+Anything else interpolated into a template literal that becomes `innerHTML`,
+`insertAdjacentHTML`, `outerHTML`, or a returned HTML string is a finding.
+
+## How to review
+
+1. Find the sinks and the generators:
+   - `grep` for `innerHTML`, `insertAdjacentHTML`, `outerHTML` across `src/`
+   - Read every file in `src/lib/generators/` and `src/main.ts` (template/render functions)
+   - `src/lib/formatters/ExpressionFormatter.ts` defines `escapeHtml` / `colouriseTextHTML`
+2. For each HTML-string template literal, trace every `${...}` interpolation:
+   - Is it file-derived? (came from a parser, a `db` record, an `EtlStep`/table/column field)
+   - If file-derived, is it escaped or colourised? If NOT → finding.
+   - `class="..."`, fixed strings, and numbers the code computed are fine.
+3. Watch for partial escaping: a row helper that escapes 3 fields but forgets the 4th.
+4. Watch attribute context: a value inside `title="${...}"` or `data-x="${...}"` still needs
+   `escapeHtml` (it escapes quotes).
+
+## Output
+
+For each finding:
+- **File:line** and the offending interpolation
+- **Source** of the value (which parsed field / how it's attacker-controlled)
+- **Fix**: wrap in `ExpressionFormatter.escapeHtml(...)` (or colourise if it should be styled)
+
+End with a one-line verdict: `CLEAN` or `N findings`. Do not modify files — report only.
+If you find nothing, say so plainly; don't invent findings.

--- a/.claude/agents/xss-reviewer.md
+++ b/.claude/agents/xss-reviewer.md
@@ -22,9 +22,14 @@ even though the app is "local", a malicious sample file shared between users is 
 
 Every file-derived value placed into an HTML string MUST be one of:
 1. Passed through `ExpressionFormatter.escapeHtml()`, OR
-2. Passed through `ExpressionFormatter.colouriseTextHTML()` (escapes internally), OR
-3. A value the code itself produced from a fixed allowlist (e.g. a known icon name, a
+2. A value the code itself produced from a fixed allowlist (e.g. a known icon name, a
    numeric count, a hardcoded CSS class) — NOT raw file content.
+
+**Do NOT treat `colouriseTextHTML()` as an escaping function.** It only wraps matched
+var/table/step names in span badges; all other text — and the matched names themselves — pass
+through raw and unescaped. Input containing arbitrary HTML must be `escapeHtml()`'d *before*
+being colourised, or it's an XSS sink. Flag any code that relies on `colouriseTextHTML` alone to
+sanitise file-derived text.
 
 Anything else interpolated into a template literal that becomes `innerHTML`,
 `insertAdjacentHTML`, `outerHTML`, or a returned HTML string is a finding.

--- a/.claude/hooks/check-ts.mjs
+++ b/.claude/hooks/check-ts.mjs
@@ -10,7 +10,7 @@
  * always exits 0 so edits aren't rejected; findings are printed for Claude to act on.
  */
 import { readFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 function normalize(p) {
     return String(p || '').replace(/\\/g, '/');
@@ -33,22 +33,32 @@ try {
 const input = payload.tool_input ?? payload.toolInput ?? {};
 const file = normalize(input.file_path ?? input.filePath ?? input.path);
 
-// Only act on src TS/TSX files.
-if (!/\/src\/.*\.(ts|tsx)$/.test(file)) process.exit(0);
+// Only act on src TS/TSX files (accept absolute or relative paths).
+if (!/(?:^|\/)src\/.*\.(ts|tsx)$/.test(file)) process.exit(0);
 
 const out = [];
 
-function run(label, cmd) {
-    try {
-        execSync(cmd, { stdio: 'pipe', encoding: 'utf-8' });
-    } catch (e) {
-        const msg = `${e.stdout || ''}${e.stderr || ''}`.trim();
+// Pass args as an array (never a shell string) so a file path with shell
+// metacharacters can't inject commands. shell:true only on win32, where
+// `pnpm` resolves to a .cmd that spawn can't exec directly.
+function run(label, cmd, args) {
+    const res = spawnSync(cmd, args, {
+        stdio: 'pipe',
+        encoding: 'utf-8',
+        shell: process.platform === 'win32',
+    });
+    if (res.error) {
+        out.push(`[${label}]\n${res.error.message}`);
+        return;
+    }
+    if (res.status !== 0) {
+        const msg = `${res.stdout || ''}${res.stderr || ''}`.trim();
         if (msg) out.push(`[${label}]\n${msg}`);
     }
 }
 
-run('eslint', `pnpm exec eslint --fix "${file}"`);
-run('tsc', `pnpm exec tsc --noEmit`);
+run('eslint', 'pnpm', ['exec', 'eslint', '--fix', file]);
+run('tsc', 'pnpm', ['exec', 'tsc', '--noEmit']);
 
 if (out.length) {
     process.stderr.write(out.join('\n\n') + '\n');

--- a/.claude/hooks/check-ts.mjs
+++ b/.claude/hooks/check-ts.mjs
@@ -36,11 +36,21 @@ const file = normalize(input.file_path ?? input.filePath ?? input.path);
 // Only act on src TS/TSX files (accept absolute or relative paths; case-insensitive for Windows).
 if (!/(?:^|\/)src\/.*\.(ts|tsx)$/i.test(file)) process.exit(0);
 
+// Defence in depth: on win32 we spawn with shell:true (needed to resolve the
+// pnpm .cmd shim), so the shell could reinterpret metacharacters in `file`.
+// Reject any path containing shell-significant chars — a legitimate source
+// path under src/ never needs them.
+if (/[;&|`$(){}<>"'!*?\s\\]/.test(file.replace(/\//g, ''))) {
+    process.exit(0);
+}
+
 const out = [];
 
-// Pass args as an array (never a shell string) so a file path with shell
-// metacharacters can't inject commands. shell:true only on win32, where
-// `pnpm` resolves to a .cmd that spawn can't exec directly.
+// Args are passed as an array (not a shell string). On POSIX (shell:false)
+// this fully prevents shell interpretation of the file path. On win32 we set
+// shell:true so spawn can resolve the `pnpm` .cmd shim — there the shell CAN
+// reinterpret metacharacters, which is why the caller already rejects any
+// `file` containing shell-significant characters before we get here.
 function run(label, cmd, args) {
     const res = spawnSync(cmd, args, {
         stdio: 'pipe',

--- a/.claude/hooks/check-ts.mjs
+++ b/.claude/hooks/check-ts.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — typecheck + lint after editing a src TypeScript file.
+ *
+ * Surfaces type regressions and lint errors mid-session instead of at commit.
+ * Strict typing (no `any` on the XML spine) is a live project goal.
+ *
+ * Runs `eslint --fix` on the edited file, then a project-wide `tsc --noEmit`
+ * (tsc has no reliable single-file mode with project references). Non-blocking:
+ * always exits 0 so edits aren't rejected; findings are printed for Claude to act on.
+ */
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function normalize(p) {
+    return String(p || '').replace(/\\/g, '/');
+}
+
+let raw = '';
+try {
+    raw = readFileSync(0, 'utf-8');
+} catch {
+    process.exit(0);
+}
+
+let payload;
+try {
+    payload = JSON.parse(raw);
+} catch {
+    process.exit(0);
+}
+
+const input = payload.tool_input ?? payload.toolInput ?? {};
+const file = normalize(input.file_path ?? input.filePath ?? input.path);
+
+// Only act on src TS/TSX files.
+if (!/\/src\/.*\.(ts|tsx)$/.test(file)) process.exit(0);
+
+const out = [];
+
+function run(label, cmd) {
+    try {
+        execSync(cmd, { stdio: 'pipe', encoding: 'utf-8' });
+    } catch (e) {
+        const msg = `${e.stdout || ''}${e.stderr || ''}`.trim();
+        if (msg) out.push(`[${label}]\n${msg}`);
+    }
+}
+
+run('eslint', `pnpm exec eslint --fix "${file}"`);
+run('tsc', `pnpm exec tsc --noEmit`);
+
+if (out.length) {
+    process.stderr.write(out.join('\n\n') + '\n');
+}
+process.exit(0);

--- a/.claude/hooks/check-ts.mjs
+++ b/.claude/hooks/check-ts.mjs
@@ -33,8 +33,8 @@ try {
 const input = payload.tool_input ?? payload.toolInput ?? {};
 const file = normalize(input.file_path ?? input.filePath ?? input.path);
 
-// Only act on src TS/TSX files (accept absolute or relative paths).
-if (!/(?:^|\/)src\/.*\.(ts|tsx)$/.test(file)) process.exit(0);
+// Only act on src TS/TSX files (accept absolute or relative paths; case-insensitive for Windows).
+if (!/(?:^|\/)src\/.*\.(ts|tsx)$/i.test(file)) process.exit(0);
 
 const out = [];
 

--- a/.claude/hooks/guard-lockfiles.mjs
+++ b/.claude/hooks/guard-lockfiles.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook — blocks hand-edits to pnpm lock/workspace files.
+ *
+ * These regenerate via pnpm. Hand-edits have repeatedly broken CI
+ * (ERR_PNPM_IGNORED_BUILDS, malformed pnpm-workspace.yaml). Change deps
+ * with `pnpm add/remove`, not by editing these files.
+ *
+ * Reads the tool-call payload on stdin, exits 2 (with a message on stderr)
+ * to block, exits 0 to allow.
+ */
+import { readFileSync } from 'node:fs';
+
+const GUARDED = ['pnpm-lock.yaml', 'pnpm-workspace.yaml'];
+
+function normalize(p) {
+    return String(p || '').replace(/\\/g, '/').toLowerCase();
+}
+
+let raw = '';
+try {
+    raw = readFileSync(0, 'utf-8');
+} catch {
+    process.exit(0); // no stdin → nothing to guard
+}
+
+let payload;
+try {
+    payload = JSON.parse(raw);
+} catch {
+    process.exit(0);
+}
+
+const input = payload.tool_input ?? payload.toolInput ?? {};
+const target = normalize(input.file_path ?? input.filePath ?? input.path);
+
+if (GUARDED.some((name) => target.endsWith('/' + name) || target.endsWith(name))) {
+    process.stderr.write(
+        `Blocked: ${target.split('/').pop()} is managed by pnpm and must not be hand-edited.\n` +
+            `Change dependencies with \`pnpm add\` / \`pnpm remove\` and let pnpm regenerate it.\n`
+    );
+    process.exit(2);
+}
+
+process.exit(0);

--- a/.claude/hooks/guard-lockfiles.mjs
+++ b/.claude/hooks/guard-lockfiles.mjs
@@ -33,10 +33,13 @@ try {
 
 const input = payload.tool_input ?? payload.toolInput ?? {};
 const target = normalize(input.file_path ?? input.filePath ?? input.path);
+const basename = target.split('/').pop();
 
-if (GUARDED.some((name) => target.endsWith('/' + name) || target.endsWith(name))) {
+// Exact basename match only — don't block files that merely end with the
+// guarded name (e.g. docs/my-pnpm-lock.yaml).
+if (GUARDED.includes(basename)) {
     process.stderr.write(
-        `Blocked: ${target.split('/').pop()} is managed by pnpm and must not be hand-edited.\n` +
+        `Blocked: ${basename} is managed by pnpm and must not be hand-edited.\n` +
             `Change dependencies with \`pnpm add\` / \`pnpm remove\` and let pnpm regenerate it.\n`
     );
     process.exit(2);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-lockfiles.mjs\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-ts.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/gen-etl-fixture/SKILL.md
+++ b/.claude/skills/gen-etl-fixture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: gen-etl-fixture
+description: Scaffold a fixture-based Vitest test for a new ETL step type or parsing edge case in the T1 Analyser. Use when adding support for a new .t1etlp step type, reproducing a parse bug from a user-reported file, or asked to "add a fixture", "write an ETL test", or "cover this step type". User-invoked.
+disable-model-invocation: true
+---
+
+# Generate ETL Fixture Test
+
+Tests here are **fixture-driven**: feed XML, assert the parsed/rendered output. This skill
+scaffolds a new fixture test matching that pattern (see `tests/EtlParser.KitchenSink.test.ts`
+and `tests/StepDescriptors.test.ts` for the canonical style).
+
+## Inputs to gather
+
+1. **Step type / scenario** — the `RawType` discriminator or the edge case (e.g. a new
+   `MergeWarehouse` step, or "DTS step with empty Outputs").
+2. **Source XML** — either a real snippet from a user file under `samples/ETLs/`, or a minimal
+   handcrafted `.t1etlp` fragment. Prefer the smallest XML that reproduces the behaviour.
+3. **Expected output** — what `EtlParser.parseSteps` (the `EtlStep` `info` object) should yield,
+   or what the generator should render.
+
+## The EtlStep shape (assert against these)
+
+`src/lib/parsers/types.ts`:
+- `RawType: string` — type discriminator
+- `Step?`, `Name?`, `Value?` — labels
+- `Details: string[]` — human-readable detail lines
+- `Inputs?: string[]`, `Outputs?: string[]`, `Output?: {type?, name?} | null`
+- `Rules?: LogicRule[]` ( `{outcome, condition}` ) — for decision/logic steps
+- `children?: EtlStep[]` — nesting (groups, loops)
+- `Icon?: string` — authoritative glyph (single source for HTML + Mermaid)
+- `Phase?`, `Context?`, `SourceType?`, `id?`
+
+## Watch the known traps (these have all caused bugs)
+
+- **Falsy guards**: use `val == null`, not `!val` — `0`, `''`, seq-`0` are valid data.
+- **`#text` extraction**: text nodes arrive as `#text`; use `EtlParser.getTextSafe`.
+- **Control flow ≠ data lineage**: `StartProcess` outputs are control flow, NOT data outputs —
+  don't assert them as `Outputs`.
+- **Icon authority**: `item.Icon` is authoritative; `RawType` is only the fallback.
+- **Sort stability**: steps sort by sequence; seq `0` must not be dropped or NaN-keyed.
+
+## Scaffold
+
+Create `tests/EtlParser.<ScenarioName>.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { EtlParser } from '../src/lib/parsers/EtlParser';
+
+// Minimal .t1etlp fragment reproducing <scenario>.
+const XML = `<!-- paste minimal step XML here -->`;
+
+describe('EtlParser — <scenario>', () => {
+    it('parses <RawType> into the expected EtlStep', () => {
+        const steps = EtlParser.parseSteps(/* parsed XML input — match how existing tests feed it */);
+        const step = steps.find((s) => s.RawType === '<RawType>');
+
+        expect(step).toBeDefined();
+        expect(step?.Details).toContain('<expected detail>');
+        expect(step?.Outputs ?? []).toEqual([/* expected, or [] for control-flow steps */]);
+        // Guard the traps: seq-0 present, 0/'' preserved, Icon authoritative.
+    });
+});
+```
+
+Open an existing test first to copy the exact parser entry point and input-shaping (the precise
+`parseSteps` call signature and how XML is pre-parsed differ — mirror the real tests, don't guess).
+
+## Finish
+Run `pnpm test` and confirm the new test passes (or fails red first if TDD-ing the parser change).

--- a/.claude/skills/verify-app/SKILL.md
+++ b/.claude/skills/verify-app/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: verify-app
+description: Verify a UI/render change in the T1 Analyser by running the dev server, loading a real sample file, and checking the rendered view + console. Use after changing any generator, formatter, main.ts render path, or styling — and whenever asked to "verify the app", "check it renders", or "confirm the change works in the browser".
+---
+
+# Verify App
+
+The T1 Analyser is browser-rendered (vanilla DOM, no framework). DOM-only assertions miss
+visual/console regressions. This skill runs the real app against a real sample and checks it.
+
+## When to use
+
+After editing: `src/lib/generators/*`, `src/lib/formatters/*`, `src/main.ts` render/template
+functions, `src/style.css`, or anything that changes what the user sees.
+
+## Steps
+
+### 1. Start the dev server
+```bash
+pnpm dev        # Vite, http://localhost:5173
+```
+Run it in the background; don't block on it.
+
+### 2. Open the app
+Use Chrome DevTools MCP (preferred — real screenshots + console + network) or Claude Preview:
+- Navigate to `http://localhost:5173`.
+- **OfflineVerifier blocks the UI until the device looks offline.** In the browser, this overlay
+  may appear. For verification you usually need to dismiss/bypass it — check `OfflineVerifier.ts`
+  for the current bypass (it monitors `navigator.onLine` + active pings). If it blocks rendering,
+  note it and use the test suite for logic, the browser only for the visual layer you can reach.
+
+### 3. Load a sample
+Samples live in `samples/`. Good ETL choices:
+- `samples/ETLs/FPR_TRANS_*.t1etlp` — general ETL flow
+- `samples/ETLs/SAVETODATETIME_*.t1etlp` — smaller, fast
+- `samples/ETLs/COMMENTS_*.t1etlp` — comment-heavy (XSS-relevant)
+
+Data Models: `samples/Data Models/`. Drive the file-input / drag-drop the app exposes (inspect
+`FileProcessor` wiring in `main.ts` for the input element id).
+
+### 4. Check
+- **Console clean** — no errors/warnings (list_console_messages / preview_console_logs).
+- **Render correct** — the flow diagram / step list / table view shows expected content.
+  Screenshot it.
+- **Network silent** — local-first app should make no data-path requests (list_network_requests).
+- If you changed perf-sensitive code, run a Lighthouse audit or check that the `mermaid` chunk
+  only loads when a diagram renders (Network tab).
+
+### 5. Report
+Share the screenshot + a one-line verdict. If broken: read the source, fix, re-check from step 3.
+Never ask the user to check manually — verify and show proof.
+
+## Fallback
+If the browser path is blocked (offline overlay, MCP unavailable): run `pnpm test` for logic
+coverage and say explicitly that the visual layer was not verified in-browser.

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,9 @@ package-lock.json
 .opencode/
 .openwork/
 opencode.jsonc
-.claude/
+
+# Claude Code: commit shared config, ignore local-only overrides
+.claude/settings.local.json
+.claude/launch.json
+.claude/*.local
+.claude/.session*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
+      "args": ["-y", "@upstash/context7-mcp@3.1.0"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ backend, no telemetry, no network calls in the data path.
 
 ## Stack
 
-- **Vite** (rolldown-vite) + **TypeScript** (strict-ish, no framework — vanilla DOM)
+- **Vite** (rolldown-vite) + **TypeScript** (`strict: true`, no framework — vanilla DOM)
 - **Tailwind v4** styling
-- **Dexie** (IndexedDB) — `src/lib/db.ts`, stores `reports` + `dataModels`
+- **Dexie** (IndexedDB) — `src/lib/db.ts`, stores `reports`, `dataModels`, `dashboards`
 - **fast-xml-parser** — XML ingestion
 - **docx** — Word export; **mermaid** — flow diagrams (lazy-loaded); **jszip** — archive reads
 - **Vitest** + jsdom tests; **pnpm@11.1.2** (pinned)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,12 @@ See `docs/ARCHITECTURE.md`, `docs/API_REFERENCE.md`, `docs/FILE_FORMATS.md` for 
 ### Security: escape ALL file-derived text in HTML
 Generators build HTML via string concatenation. Every file-derived value interpolated into an
 HTML string (incl. `innerHTML`/`insertAdjacentHTML` sinks) **MUST** pass through
-`ExpressionFormatter.escapeHtml()` — UNLESS it goes through `colouriseTextHTML` (which escapes
-internally). XSS has regressed here 3× (SmartDesc, `main.ts` itemRow, `EtlGenerator`). Treat
-unescaped interpolation of parsed XML as a bug.
+`ExpressionFormatter.escapeHtml()`. Note: `colouriseTextHTML` does **NOT** fully escape — it
+only wraps matched var/table/step names in span badges and passes all other text (and the
+matched names themselves) through raw, so its output is XSS-unsafe for arbitrary HTML. Escape
+the input with `escapeHtml()` *before* colourising if it can contain arbitrary HTML. XSS has
+regressed here 3× (SmartDesc, `main.ts` itemRow, `EtlGenerator`). Treat unescaped interpolation
+of parsed XML as a bug.
 
 ### Typing: no `any` on the XML spine
 Deep XML is typed via `XmlNode`/`XmlValue`/`asNode()` in `parsers/types.ts`. Don't reintroduce

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. User instructions override this file.
+
+## What this is
+
+**TechnologyOne Analyser** (`t1-analyser`) — browser-only utility that parses TechnologyOne
+`.t1etlp` (ETL) and `.t1dm` (Data Model) files, stores them locally in IndexedDB, and renders
+technical views + downloadable `.docx` reports. **Local-first, air-gapped, zero data
+exfiltration** — `OfflineVerifier` blocks the UI until the device is confirmed offline. No
+backend, no telemetry, no network calls in the data path.
+
+## Stack
+
+- **Vite** (rolldown-vite) + **TypeScript** (strict-ish, no framework — vanilla DOM)
+- **Tailwind v4** styling
+- **Dexie** (IndexedDB) — `src/lib/db.ts`, stores `reports` + `dataModels`
+- **fast-xml-parser** — XML ingestion
+- **docx** — Word export; **mermaid** — flow diagrams (lazy-loaded); **jszip** — archive reads
+- **Vitest** + jsdom tests; **pnpm@11.1.2** (pinned)
+
+## Architecture
+
+`src/main.ts` = central controller (state, routing, `render()` loop, HTML template fns,
+`window.*` global event handlers). Core logic in `src/lib/`:
+
+- `FileProcessor.ts` — ingestion gateway: detect type → parse → store
+- `parsers/` — `EtlParser`, `DataModelParser`, `DashboardParser`, `StepDescriptors`, shared `types.ts`
+- `generators/` — return **HTML strings** (`EtlGenerator`, `DataModelGenerator`, `DashboardGenerator`),
+  `DocxGenerator` (+`DocxPrimitives`), `MermaidGenerator`, `EtlSummary`
+- `formatters/ExpressionFormatter.ts` — text colourising + **`escapeHtml`**
+- `ux/OfflineVerifier.ts` — air-gap enforcement overlay
+
+See `docs/ARCHITECTURE.md`, `docs/API_REFERENCE.md`, `docs/FILE_FORMATS.md` for depth.
+
+## Conventions — follow these
+
+### Security: escape ALL file-derived text in HTML
+Generators build HTML via string concatenation. Every file-derived value interpolated into an
+HTML string (incl. `innerHTML`/`insertAdjacentHTML` sinks) **MUST** pass through
+`ExpressionFormatter.escapeHtml()` — UNLESS it goes through `colouriseTextHTML` (which escapes
+internally). XSS has regressed here 3× (SmartDesc, `main.ts` itemRow, `EtlGenerator`). Treat
+unescaped interpolation of parsed XML as a bug.
+
+### Typing: no `any` on the XML spine
+Deep XML is typed via `XmlNode`/`XmlValue`/`asNode()` in `parsers/types.ts`. Don't reintroduce
+`any` in parsers/generators. Guard falsy values explicitly (`val == null`, not `!val`) — `0`,
+`''`, and seq-`0` are valid data. Extract text via `EtlParser.getTextSafe` / `#text` handling.
+
+### Tests: fixture-driven
+Tests live in `tests/`, named `<Module>.test.ts`. Pattern is fixture-based — feed XML, assert
+parsed/rendered output (see `EtlParser.KitchenSink.test.ts`, `StepDescriptors.test.ts`). Sample
+files in `samples/{ETLs,Data Models,Dashboards,...}`. Add a fixture + expected output for every
+new step type or edge case.
+
+### Commits / releases
+Conventional Commits enforced by commitlint + Husky. `semantic-release` cuts versions from
+commit history — `feat:`/`fix:` matter. lint-staged runs `eslint --fix` + `prettier` on commit.
+
+### Never hand-edit lockfiles
+`pnpm-lock.yaml` and `pnpm-workspace.yaml` regenerate via pnpm. Hand-edits have caused
+`ERR_PNPM_IGNORED_BUILDS` and broken CI repeatedly. Change deps via `pnpm` commands, not by
+editing these files.
+
+## Commands
+
+```bash
+pnpm dev            # vite dev server (port 5173)
+pnpm build          # tsc + vite build + service-worker build
+pnpm test           # vitest (watch)
+pnpm test:coverage  # vitest run --coverage
+pnpm lint           # eslint src
+pnpm lint:fix       # eslint --fix
+pnpm format         # prettier --write src
+```
+
+## Verifying UI changes
+
+App is browser-rendered. To verify a render change: start `pnpm dev`, load a sample from
+`samples/ETLs/` (e.g. `FPR_TRANS_*.t1etlp`), check the flow diagram renders + console is clean.
+Chrome DevTools MCP is available for real screenshots / console / network / Lighthouse — prefer
+it over DOM-only assertions. See the `verify-app` skill.
+
+## Style
+
+Prettier: 4-space indent, single quotes, semicolons, 120 print width, ES5 trailing commas.


### PR DESCRIPTION
## What

Project-shared Claude Code config so the agent — and teammates — automatically work to this repo's conventions.

- **CLAUDE.md** — stack, architecture, conventions (escapeHtml-everywhere, no-`any` XML spine, fixture tests, conventional commits, never hand-edit lockfiles), commands, verify flow.
- **Hooks** (`.claude/settings.json` + portable node scripts):
  - `guard-lockfiles.mjs` — PreToolUse, blocks hand-edits to `pnpm-lock.yaml` / `pnpm-workspace.yaml` (these broke CI repeatedly: `ERR_PNPM_IGNORED_BUILDS`, malformed workspace file).
  - `check-ts.mjs` — PostToolUse, `eslint --fix` + `tsc --noEmit` on edited `src/**/*.ts`. Non-blocking.
- **Subagents** (`.claude/agents/`):
  - `xss-reviewer` — audits HTML sinks for unescaped file-derived text (XSS regressed 3× here).
  - `bundle-guard` — guards eager heavy imports + chunk splitting / lazy-load.
- **Skills** (`.claude/skills/`):
  - `verify-app` — run dev server, load a sample, check render + console (both-invocable).
  - `gen-etl-fixture` — scaffold fixture tests, encodes the known parser traps (user-only).
- **.mcp.json** — `context7` for live `docx`/`mermaid`/`dexie` docs.
- **.gitignore** — un-ignore shared `.claude` config; keep local overrides (`settings.local.json`, `launch.json`, `*.local`) ignored.

## Why

No `CLAUDE.md` or agent config existed, yet the repo has rich, hard-won conventions (escape-everything, fixture tests, pinned pnpm). This encodes them so they're applied automatically instead of rediscovered each session.

## Reviewer notes

- Hooks shell out to `node` directly → portable across win32 + bash. Active after Claude Code reloads config.
- `check-ts` runs full-project `tsc` per edit (project-references = no reliable single-file mode). Switch to lint-only if too slow.
- `context7` MCP spawns via `npx` on next session; `chrome-devtools` is already plugin-connected.
- **Heads-up (not in this PR):** the `pnpm build` during commit flagged that `MermaidGenerator` is statically imported by `DocxGenerator` + `EtlGenerator`, so the 2.8MB mermaid chunk is **not** actually lazy-loaded despite the dynamic import in `main.ts`. The new `bundle-guard` agent exists to catch exactly this — worth a follow-up.
- No source code touched; config + docs only. Tests stay 71/71 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)