### PR TITLE
feat(xlone): XlOne Reports (.t1xl) module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We are currently acting as a "Beta" for the **ETL** and **Data Model** modules. 
 2.  **Data Model Accuracy**: Are all Tables, Joins, and Filters displaying correctly for your `.t1dm` files?
 3.  **Parsing Edge Cases**: If you have a file that fails to parse or looks "empty", please report it.
 
-*Note: Dashboards and XlOne reports are currently in active development (see Roadmap).*
+*Note: Playlists and theming/responsiveness are currently in active development (see Roadmap).*
 
 ## Roadmap
 
@@ -57,11 +57,11 @@ We are currently acting as a "Beta" for the **ETL** and **Data Model** modules. 
 - [x] **Data Models (`.t1dm`)**:
     - Visualisation of Tables, Joins, and Sources.
     - Deep parsing of "Query" definitions and variable dependencies.
-- [ ] **Dashboards (`.t1db`)**:
+- [x] **Dashboards (`.t1db`)**:
     - Parsing `Dashboard.xml` and `Visualisations.xml` layouts.
     - Visualizing Widget placement and data binding.
     - Extracting Filter dependency chains.
-- [ ] **XlOne Reports (`.t1xl`)**:
+- [x] **XlOne Reports (`.t1xl`)**:
     - Decoding proprietary Excel-based report definitions.
     - Mapping Data Model dependencies within spreadsheet cells.
 

--- a/src/lib/FileProcessor.ts
+++ b/src/lib/FileProcessor.ts
@@ -4,6 +4,7 @@ import { db } from './db';
 
 import { DataModelParser } from './parsers/DataModelParser';
 import { DashboardParser } from './parsers/DashboardParser';
+import { XlOneParser } from './parsers/XlOneParser';
 import { asNode, type XmlNode, type XmlValue } from './parsers/types';
 
 const parser = new XMLParser({
@@ -64,6 +65,10 @@ export class FileProcessor {
 
         if (file.name.toLowerCase().endsWith('.t1db')) {
             return this.processDashboard(file);
+        }
+
+        if (file.name.toLowerCase().endsWith('.t1xl')) {
+            return this.processXlReport(file);
         }
 
         // 1. Unzip
@@ -218,6 +223,33 @@ export class FileProcessor {
         });
 
         console.log(`Saved Dashboard ${id} to DB`);
+        return id as number;
+    }
+
+    private static async processXlReport(file: File): Promise<number> {
+        const content = await XlOneParser.parse(file);
+
+        const name = content.header.title || file.name.replace(/\.t1xl$/i, '');
+
+        const metadata = {
+            name,
+            id: content.header.reportId || 'N/A',
+            description: content.header.description,
+            owner: content.header.userId || 'Unknown',
+            parentPath: content.header.parentPath,
+            type: content.header.type,
+            datasource: content.header.datasource,
+            dateModified: new Date().toISOString(),
+        };
+
+        const id = await db.xlReports.add({
+            filename: file.name,
+            metadata,
+            content,
+            dateAdded: new Date(),
+        });
+
+        console.log(`Saved XlOne Report ${id} to DB`);
         return id as number;
     }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Table } from 'dexie';
-import type { DataModelParsed, DashboardParsed } from './parsers/types';
+import type { DataModelParsed, DashboardParsed, XlReportParsed } from './parsers/types';
 
 export interface Report {
     id?: number;
@@ -58,10 +58,29 @@ export interface Dashboard {
     stepNotes?: Record<string, string>; // Map of widgetId -> note text
 }
 
+export interface XlReport {
+    id?: number;
+    filename: string;
+    metadata: {
+        name: string;
+        id?: string;
+        description?: string;
+        owner?: string;
+        parentPath?: string;
+        type?: string;
+        datasource?: string;
+        dateModified?: string;
+    };
+    content: XlReportParsed;
+    dateAdded: Date;
+    stepNotes?: Record<string, string>;
+}
+
 export class T1AnalyserDB extends Dexie {
     reports!: Table<Report>;
     dataModels!: Table<DataModel>;
     dashboards!: Table<Dashboard>;
+    xlReports!: Table<XlReport>;
 
     constructor() {
         super('T1AnalyserDB');
@@ -75,6 +94,10 @@ export class T1AnalyserDB extends Dexie {
         // Version 3: Add dashboards
         this.version(3).stores({
             dashboards: '++id, filename, dateAdded',
+        });
+        // Version 4: Add xlReports (XlOne reports)
+        this.version(4).stores({
+            xlReports: '++id, filename, dateAdded',
         });
     }
 }

--- a/src/lib/generators/XlOneGenerator.ts
+++ b/src/lib/generators/XlOneGenerator.ts
@@ -1,0 +1,186 @@
+import { db } from '../db';
+import { ExpressionFormatter } from '../formatters/ExpressionFormatter';
+import type { XlReportParsed, XlColumnDefn } from '../parsers/types';
+
+const esc = (v: unknown): string => ExpressionFormatter.escapeHtml(String(v ?? ''));
+
+/** Minimal shape of a Data Model record used for cross-module lineage links. */
+type DmRef = { id?: number; metadata: { name: string } };
+
+export class XlOneGenerator {
+    static async generateHtmlView(id: number): Promise<string> {
+        const record = await db.xlReports.get(id);
+        if (!record) throw new Error('XlOne Report not found');
+
+        const c: XlReportParsed = record.content;
+        const h = c.header;
+        const meta = record.metadata;
+
+        // Cross-module lineage: map datasource GUID -> stored Data Model.
+        const dataModels = await db.dataModels.toArray();
+        const dmByGuid = new Map<string | undefined, DmRef>(dataModels.map((dm) => [dm.metadata.id, dm]));
+
+        const metaGrid = `
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6 p-4 bg-white border border-gray-200 rounded-lg text-sm shadow-sm">
+                ${this.metaCell('Owner', meta.owner || h.userId || '-')}
+                ${this.metaCell('Folder', (meta.parentPath || h.parentPath || '-').split('/').pop() || '-')}
+                ${this.metaCell('Type', h.type || '-')}
+                ${this.metaCell('Reporting System', h.reportingSystem || '-')}
+                ${this.metaCell('Report ID', (h.reportId || 'N/A').substring(0, 12))}
+                ${this.metaCell('Data Source', this.dmLink(h.datasource, dmByGuid))}
+            </div>
+        `;
+
+        const settingsHtml = this.renderSettings(c.sheet.settings);
+        const variablesHtml = this.renderVariables(c.sheet.variables);
+        const columnsHtml = this.renderColumns(c.sheet.columns, dmByGuid);
+        const rowCommandsHtml = this.renderRowCommands(c.sheet.rowCommands);
+
+        return `
+            <div class="doc-header">
+                <div class="flex justify-between items-start">
+                    <h2 class="text-3xl font-bold text-slate-800 tracking-tight">${esc(meta.name || h.title || 'XlOne Report')}</h2>
+                    <span class="bg-amber-100 text-amber-800 text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wide border border-amber-200">XlOne Report</span>
+                </div>
+                ${metaGrid}
+            </div>
+            <div class="doc-body space-y-8">
+                ${settingsHtml}
+                ${columnsHtml}
+                ${variablesHtml}
+                ${rowCommandsHtml}
+            </div>
+        `;
+    }
+
+    private static metaCell(label: string, value: string): string {
+        // `value` may already be safe HTML (e.g. a dmLink anchor) — those start
+        // with '<'. Plain values are escaped here.
+        return `
+            <div>
+                <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">${esc(label)}</span>
+                <span class="font-medium text-gray-800">${value.startsWith('<') ? value : esc(value)}</span>
+            </div>`;
+    }
+
+    /** Render the datasource GUID as a link if a matching Data Model is stored. */
+    private static dmLink(guid: string, dmByGuid: Map<string | undefined, DmRef>): string {
+        if (guid == null || guid === '') return esc('-');
+        const dm = dmByGuid.get(guid);
+        if (dm && dm.id != null) {
+            return `<a class="text-blue-600 hover:underline cursor-pointer" onclick="window.navigateTo('detail', ${dm.id}, 'datamodel')">${esc(dm.metadata.name)}</a>`;
+        }
+        return `<span class="font-mono text-xs text-gray-600">${esc(guid.substring(0, 12))}</span>`;
+    }
+
+    /**
+     * Label a column's data source: always show the parsed name; if the GUID
+     * matches a stored Data Model, make the name a clickable lineage link.
+     */
+    private static dataSourceLabel(
+        ds: NonNullable<XlColumnDefn['dataSource']>,
+        dmByGuid: Map<string | undefined, DmRef>
+    ): string {
+        const dm = ds.guid ? dmByGuid.get(ds.guid) : undefined;
+        if (dm && dm.id != null) {
+            return `<a class="text-blue-600 hover:underline cursor-pointer" onclick="window.navigateTo('detail', ${dm.id}, 'datamodel')">${esc(dm.metadata.name || ds.name)}</a>`;
+        }
+        const name = ds.name || ds.guid || '-';
+        return esc(name);
+    }
+
+    private static section(title: string, icon: string, badge: number | string, body: string, open = true): string {
+        return `
+            <details ${open ? 'open' : ''} class="group">
+                <summary class="flex items-center justify-between cursor-pointer list-none py-3 px-6 -mx-6 bg-slate-50 hover:bg-slate-100 transition-colors select-none border-t border-b border-slate-200">
+                    <span class="text-xl font-bold text-slate-800 flex items-center gap-3">
+                        <span class="text-lg">${icon}</span> ${esc(title)}
+                        <span class="text-xs bg-slate-100 text-slate-700 px-2 py-0.5 rounded-full border border-slate-200">${esc(badge)}</span>
+                    </span>
+                </summary>
+                <div class="pt-4 pb-2 px-2">${body}</div>
+            </details>`;
+    }
+
+    private static table(headers: string[], rows: string[][]): string {
+        if (rows.length === 0) return '';
+        const ths = headers
+            .map(
+                (header) =>
+                    `<th class="px-4 py-2 text-left text-xs font-bold text-slate-700 uppercase tracking-wider bg-slate-200 border-r border-slate-300 last:border-r-0">${esc(header)}</th>`
+            )
+            .join('');
+        const trs = rows
+            .map(
+                (r) =>
+                    `<tr class="border-t border-gray-100 hover:bg-gray-50">${r
+                        .map((cellHtml) => `<td class="px-4 py-2 text-sm text-gray-700">${cellHtml}</td>`)
+                        .join('')}</tr>`
+            )
+            .join('');
+        return `<div class="w-full overflow-hidden border border-slate-300 rounded-md mb-3"><table class="w-full divide-y divide-slate-300"><thead><tr class="bg-slate-200">${ths}</tr></thead><tbody class="bg-white divide-y divide-slate-200">${trs}</tbody></table></div>`;
+    }
+
+    private static renderSettings(settings: Record<string, string>): string {
+        const keys = Object.keys(settings);
+        if (keys.length === 0) return '';
+        const rows = keys.map((k) => [`<span class="font-semibold">${esc(k)}</span>`, esc(settings[k])]);
+        return this.section('Report Settings', '📋', keys.length, this.table(['Setting', 'Value'], rows));
+    }
+
+    private static renderVariables(variables: XlReportParsed['sheet']['variables']): string {
+        if (variables.length === 0) return '';
+        const rows = variables.map((v) => [esc(v.name), esc(v.description), esc(v.type), esc(v.value), esc(v.listValues)]);
+        return this.section(
+            'Variables',
+            '#️⃣',
+            variables.length,
+            this.table(['Name', 'Description', 'Type', 'Value', 'List Values'], rows)
+        );
+    }
+
+    private static renderColumns(columns: XlColumnDefn[], dmByGuid: Map<string | undefined, DmRef>): string {
+        if (columns.length === 0) return '';
+        const blocks = columns
+            .map((col) => {
+                const ds = col.dataSource
+                    ? this.dataSourceLabel(col.dataSource, dmByGuid)
+                    : esc('-');
+                const paramRows = Object.entries(col.parameters).map(([k, v]) => [esc(k), esc(v)]);
+                const criteriaRows = col.criteria.map((cr) => [
+                    esc(cr.columnName),
+                    esc(cr.action),
+                    esc(cr.field),
+                    esc(cr.details),
+                    esc(cr.display),
+                ]);
+                return `
+                    <div class="border border-slate-200 bg-slate-50 rounded-lg p-4 mb-3">
+                        <h3 class="text-lg font-bold text-gray-800">${esc(col.name || 'Column Definition')}</h3>
+                        <p class="text-sm text-gray-600 mt-1">Data Source: ${ds}</p>
+                        ${paramRows.length ? `<h4 class="font-semibold text-gray-700 mt-3 mb-2">Parameters</h4>${this.table(['Key', 'Value'], paramRows)}` : ''}
+                        ${criteriaRows.length ? `<h4 class="font-semibold text-gray-700 mt-3 mb-2">Criteria</h4>${this.table(['Column', 'Action', 'Field', 'Details', 'Display'], criteriaRows)}` : ''}
+                    </div>`;
+            })
+            .join('');
+        return this.section('Column Definitions', '📊', columns.length, blocks);
+    }
+
+    private static renderRowCommands(rowCommands: XlReportParsed['sheet']['rowCommands']): string {
+        if (rowCommands.length === 0) return '';
+        const rows = rowCommands.map((rc) => [
+            esc(rc.command),
+            esc(rc.details),
+            esc(rc.selection),
+            esc(rc.search),
+            esc(rc.valueFrom),
+            esc(rc.valueTo),
+        ]);
+        return this.section(
+            'Row Commands',
+            '⛓️',
+            rowCommands.length,
+            this.table(['Command', 'Details', 'Selection', 'Search', 'Value (Fr)', 'Value (To)'], rows)
+        );
+    }
+}

--- a/src/lib/generators/XlOneGenerator.ts
+++ b/src/lib/generators/XlOneGenerator.ts
@@ -27,7 +27,7 @@ export class XlOneGenerator {
                 ${this.metaCell('Type', h.type || '-')}
                 ${this.metaCell('Reporting System', h.reportingSystem || '-')}
                 ${this.metaCell('Report ID', (h.reportId || 'N/A').substring(0, 12))}
-                ${this.metaCell('Data Source', this.dmLink(h.datasource, dmByGuid))}
+                ${this.metaCell('Data Source', this.dmLink(h.datasource, dmByGuid), true)}
             </div>
         `;
 
@@ -53,13 +53,17 @@ export class XlOneGenerator {
         `;
     }
 
-    private static metaCell(label: string, value: string): string {
-        // `value` may already be safe HTML (e.g. a dmLink anchor) — those start
-        // with '<'. Plain values are escaped here.
+    /**
+     * Render a label/value cell. `value` is escaped by default; pass `isHtml=true`
+     * ONLY for values that are already-safe generated HTML (e.g. a dmLink anchor).
+     * Never infer "safe HTML" from the value's content — file-derived fields can
+     * start with '<' and would bypass escaping (XSS).
+     */
+    private static metaCell(label: string, value: string, isHtml = false): string {
         return `
             <div>
                 <span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider">${esc(label)}</span>
-                <span class="font-medium text-gray-800">${value.startsWith('<') ? value : esc(value)}</span>
+                <span class="font-medium text-gray-800">${isHtml ? value : esc(value)}</span>
             </div>`;
     }
 

--- a/src/lib/parsers/XlOneParser.ts
+++ b/src/lib/parsers/XlOneParser.ts
@@ -1,0 +1,281 @@
+import JSZip from 'jszip';
+import { XMLParser } from 'fast-xml-parser';
+import {
+    asNode,
+    type XmlNode,
+    type XmlValue,
+    type XlReportParsed,
+    type XlDefinitionSheet,
+    type XlColumnDefn,
+    type XlDataSourceRef,
+} from './types';
+
+const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+});
+
+/**
+ * Recursively parse any string field that looks like XML (mirrors the helper in
+ * DashboardParser / FileProcessor). Handles the entity-escaped DbReportDef inside
+ * the <Definition> element.
+ */
+function deepParseAllXml(obj: XmlNode): void {
+    if (!obj || typeof obj !== 'object') return;
+    Object.keys(obj).forEach((key) => {
+        const val = obj[key];
+        if (
+            (typeof val === 'string' && val.trim().startsWith('<?xml')) ||
+            (typeof val === 'string' && val.trim().startsWith('<') && val.trim().endsWith('>'))
+        ) {
+            try {
+                const parsed = parser.parse(val as string) as XmlNode;
+                obj[key] = parsed;
+                deepParseAllXml(parsed);
+            } catch (_e) {
+                // Not valid XML, leave as string
+            }
+        } else if (Array.isArray(val)) {
+            val.forEach((item) => deepParseAllXml(item as XmlNode));
+        } else if (val && typeof val === 'object') {
+            deepParseAllXml(val as XmlNode);
+        }
+    });
+}
+
+/** Coerce a leaf XmlValue to a string, extracting `#text` for attributed nodes. */
+function getText(val: XmlValue): string {
+    if (val == null) return '';
+    if (typeof val === 'object') {
+        const node = asNode(val);
+        return node && typeof node['#text'] === 'string' ? node['#text'] : '';
+    }
+    return String(val);
+}
+
+function emptySheet(): XlDefinitionSheet {
+    return { settings: {}, variables: [], columns: [], rowCommands: [] };
+}
+
+/** Parse a `key=value;key=value;` string into an object (trailing `;` tolerated). */
+function parseKvString(raw: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    if (raw == null || raw === '') return out;
+    raw.split(';').forEach((pair) => {
+        if (pair === '') return;
+        const eq = pair.indexOf('=');
+        if (eq === -1) return;
+        const k = pair.slice(0, eq).trim();
+        const v = pair.slice(eq + 1).trim();
+        if (k !== '') out[k] = v;
+    });
+    return out;
+}
+
+/** Parse "Name (System) (GUID)" into its parts. GUID is the last (...) group. */
+function parseDataSourceRef(raw: string): XlDataSourceRef {
+    const guidMatch = raw.match(/\(([0-9a-fA-F-]{36})\)\s*$/);
+    const guid = guidMatch ? guidMatch[1] : '';
+    const rest = guid ? raw.slice(0, guidMatch!.index).trim() : raw.trim();
+    const sysMatch = rest.match(/\(([^)]*)\)\s*$/);
+    const system = sysMatch ? sysMatch[1] : '';
+    const name = sysMatch ? rest.slice(0, sysMatch.index).trim() : rest;
+    return { raw, name, system, guid };
+}
+
+/** Build the shared-strings array from sharedStrings.xml. */
+function readSharedStrings(xml: string): string[] {
+    const root = parser.parse(xml) as XmlNode;
+    const sst = asNode(root.sst);
+    if (!sst) return [];
+    const siRaw = sst.si;
+    const siList = (Array.isArray(siRaw) ? siRaw : siRaw == null ? [] : [siRaw]) as XmlValue[];
+    return siList.map((si) => {
+        const node = asNode(si);
+        if (!node) return getText(si);
+        // <si><t>text</t></si> OR <si><r><t>..</t></r>...</si> (rich text runs)
+        if (node.t != null) return getText(node.t);
+        if (node.r != null) {
+            const runs = (Array.isArray(node.r) ? node.r : [node.r]) as XmlValue[];
+            return runs.map((run) => getText(asNode(run)?.t)).join('');
+        }
+        return '';
+    });
+}
+
+/** Column letters from a cell ref like "B12" -> "B". */
+function colOf(ref: string): string {
+    const m = ref.match(/^([A-Z]+)/);
+    return m ? m[1] : '';
+}
+/** Row number from a cell ref like "B12" -> 12. */
+function rowOf(ref: string): number {
+    const m = ref.match(/(\d+)$/);
+    return m ? Number(m[1]) : 0;
+}
+
+/** Build a Map<cellRef, string> resolving shared-string cells to text. */
+function readSheetCells(xml: string, shared: string[]): Map<string, string> {
+    const root = parser.parse(xml) as XmlNode;
+    const sheetData = asNode(asNode(root.worksheet)?.sheetData);
+    const cells = new Map<string, string>();
+    if (!sheetData) return cells;
+    const rowsRaw = sheetData.row;
+    const rows = (Array.isArray(rowsRaw) ? rowsRaw : rowsRaw == null ? [] : [rowsRaw]) as XmlValue[];
+    rows.forEach((r) => {
+        const rowNode = asNode(r);
+        if (!rowNode) return;
+        const cRaw = rowNode.c;
+        const cArr = (Array.isArray(cRaw) ? cRaw : cRaw == null ? [] : [cRaw]) as XmlValue[];
+        cArr.forEach((c) => {
+            const cNode = asNode(c);
+            if (!cNode) return;
+            const ref = getText(cNode['@_r']);
+            if (ref === '') return;
+            const tType = getText(cNode['@_t']);
+            const v = getText(cNode.v);
+            if (tType === 's') {
+                const idx = Number(v);
+                cells.set(ref, shared[idx] != null ? shared[idx] : '');
+            } else if (v !== '') {
+                cells.set(ref, v);
+            } else {
+                const inline = getText(asNode(cNode.is)?.t);
+                if (inline !== '') cells.set(ref, inline);
+            }
+        });
+    });
+    return cells;
+}
+
+/**
+ * Reconstruct the Definition sheet sections from a resolved cell map. The sheet
+ * is a labelled grid: a label in column A, its value in the next column(s).
+ * Section headers (REPORT SETTINGS / COLUMN DEFINITION / ROW COMMANDS) switch
+ * the active block. Column B holds the value for a column-A label.
+ */
+function reconstructSheet(cells: Map<string, string>): XlDefinitionSheet {
+    const sheet: XlDefinitionSheet = emptySheet();
+    if (cells.size === 0) return sheet;
+
+    // Group cells by row, ordered.
+    const byRow = new Map<number, Map<string, string>>();
+    for (const [ref, val] of cells) {
+        const rn = rowOf(ref);
+        if (!byRow.has(rn)) byRow.set(rn, new Map());
+        byRow.get(rn)!.set(colOf(ref), val);
+    }
+    const rowNums = Array.from(byRow.keys()).sort((a, b) => a - b);
+
+    type Block = 'none' | 'settings' | 'column';
+    let block: Block = 'none';
+    let current: XlColumnDefn | null = null;
+
+    const flush = () => {
+        if (current) {
+            sheet.columns.push(current);
+            current = null;
+        }
+    };
+
+    for (const rn of rowNums) {
+        const cols = byRow.get(rn)!;
+        const a = (cols.get('A') || '').trim();
+        const b = (cols.get('B') || '').trim();
+
+        if (a === 'REPORT SETTINGS') {
+            block = 'settings';
+            continue;
+        }
+        if (a === 'REPORT VARIABLES') {
+            block = 'none';
+            continue;
+        }
+        if (a === 'COLUMN DEFINITION') {
+            flush();
+            block = 'column';
+            current = { name: '', dataSource: null, parameters: {}, runtime: {}, criteria: [] };
+            continue;
+        }
+        if (a === 'ROW COMMANDS') {
+            flush();
+            block = 'none';
+            continue;
+        }
+        if (a === 'FORMAT CIAXLONE REPORT' || a === '') continue;
+
+        const label = a.replace(/:$/, '');
+
+        if (block === 'settings') {
+            sheet.settings[label] = b;
+        } else if (block === 'column' && current) {
+            if (label === 'Name') current.name = b;
+            else if (label === 'Data Source') current.dataSource = parseDataSourceRef(b);
+            else if (label === 'Parameters') current.parameters = parseKvString(b);
+            else if (label === 'Runtime') current.runtime = parseKvString(b);
+        }
+    }
+    flush();
+    return sheet;
+}
+
+export class XlOneParser {
+    static async parse(file: File): Promise<XlReportParsed> {
+        const zip = await JSZip.loadAsync(file);
+
+        // --- Outer Report.xml ---
+        const reportFile = zip.file('Report.xml');
+        let headerNode: XmlNode = {};
+        if (reportFile) {
+            const content = await reportFile.async('string');
+            try {
+                const parsed = parser.parse(content) as XmlNode;
+                deepParseAllXml(parsed);
+                headerNode = asNode(parsed.MyXLOneHeader) || {};
+            } catch (e) {
+                console.warn('Failed to parse Report.xml', e);
+            }
+        }
+
+        const definition = asNode(headerNode.Definition)
+            ? asNode(asNode(headerNode.Definition)?.DbReportDef) || {}
+            : {};
+
+        const header = {
+            reportId: getText(headerNode.ReportId),
+            title: getText(headerNode.Title),
+            description: getText(headerNode.Description),
+            category: getText(headerNode.Category),
+            type: getText(headerNode.Type),
+            sheetName: getText(headerNode.SheetName),
+            userId: getText(headerNode.UserId),
+            datasource: getText(headerNode.Datasource),
+            reportingSystem: getText(headerNode.ReportingSystem),
+            parentPath: getText(headerNode.ParentFileItemPath),
+            storageType: getText(headerNode.ReportStorageType),
+        };
+
+        // --- Embedded xlsx Definition sheet ---
+        let sheet = emptySheet();
+        const xlsxName = Object.keys(zip.files).find((n) => n.toLowerCase().endsWith('.xlsx'));
+        if (xlsxName) {
+            try {
+                const xlsxBytes = await zip.file(xlsxName)!.async('uint8array');
+                const inner = await JSZip.loadAsync(xlsxBytes);
+                const ssFile = inner.file('xl/sharedStrings.xml');
+                const sheetFile =
+                    inner.file('xl/worksheets/sheet1.xml') ||
+                    inner.file(Object.keys(inner.files).find((n) => /xl\/worksheets\/.*\.xml$/.test(n)) || '');
+                const shared = ssFile ? readSharedStrings(await ssFile.async('string')) : [];
+                if (sheetFile) {
+                    const cells = readSheetCells(await sheetFile.async('string'), shared);
+                    sheet = reconstructSheet(cells);
+                }
+            } catch (e) {
+                console.warn('Failed to parse embedded xlsx', e);
+            }
+        }
+
+        return { header, definition, sheet };
+    }
+}

--- a/src/lib/parsers/XlOneParser.ts
+++ b/src/lib/parsers/XlOneParser.ts
@@ -7,6 +7,7 @@ import {
     type XlReportParsed,
     type XlDefinitionSheet,
     type XlColumnDefn,
+    type XlCriteriaRow,
     type XlDataSourceRef,
 } from './types';
 
@@ -167,15 +168,53 @@ function reconstructSheet(cells: Map<string, string>): XlDefinitionSheet {
     }
     const rowNums = Array.from(byRow.keys()).sort((a, b) => a - b);
 
-    type Block = 'none' | 'settings' | 'column';
+    // Block discriminator. 'variables'/'rowcommands' are tabular (header row of
+    // column labels, then data rows). 'settings'/'column' are label:value rows.
+    type Block = 'none' | 'settings' | 'column' | 'variables' | 'rowcommands';
     let block: Block = 'none';
     let current: XlColumnDefn | null = null;
 
-    const flush = () => {
+    // Header column-letter -> field label, captured from the first row after a
+    // tabular section header (REPORT VARIABLES / ROW COMMANDS).
+    let tableHeader: Map<string, string> | null = null;
+
+    // Criteria for the current column is a vertical label:value block in a side
+    // column (col G label, col H value in the samples). A new "Column Name:" label
+    // starts a fresh criteria row.
+    let pendingCriteria: XlCriteriaRow | null = null;
+    const criteriaFieldFor = (label: string): keyof XlCriteriaRow | null => {
+        switch (label) {
+            case 'Column Name':
+                return 'columnName';
+            case 'Action':
+                return 'action';
+            case 'Field':
+                return 'field';
+            case 'Details':
+                return 'details';
+            case 'Display':
+                return 'display';
+            default:
+                return null;
+        }
+    };
+    const flushCriteria = () => {
+        if (pendingCriteria && current) current.criteria.push(pendingCriteria);
+        pendingCriteria = null;
+    };
+
+    const flushColumn = () => {
+        flushCriteria();
         if (current) {
             sheet.columns.push(current);
             current = null;
         }
+    };
+
+    /** Read the data cells of a tabular row against the captured header map. */
+    const rowValues = (cols: Map<string, string>): string[] => {
+        if (!tableHeader) return [];
+        return Array.from(tableHeader.keys()).map((col) => (cols.get(col) || '').trim());
     };
 
     for (const rn of rowNums) {
@@ -183,39 +222,103 @@ function reconstructSheet(cells: Map<string, string>): XlDefinitionSheet {
         const a = (cols.get('A') || '').trim();
         const b = (cols.get('B') || '').trim();
 
+        // --- Section headers switch the active block ---
         if (a === 'REPORT SETTINGS') {
+            flushColumn();
             block = 'settings';
+            tableHeader = null;
             continue;
         }
         if (a === 'REPORT VARIABLES') {
-            block = 'none';
+            flushColumn();
+            block = 'variables';
+            tableHeader = null; // captured on the next row
             continue;
         }
         if (a === 'COLUMN DEFINITION') {
-            flush();
+            flushColumn();
             block = 'column';
             current = { name: '', dataSource: null, parameters: {}, runtime: {}, criteria: [] };
+            tableHeader = null;
             continue;
         }
         if (a === 'ROW COMMANDS') {
-            flush();
-            block = 'none';
+            flushColumn();
+            block = 'rowcommands';
+            tableHeader = null; // captured on the next row
             continue;
         }
-        if (a === 'FORMAT CIAXLONE REPORT' || a === '') continue;
+        if (a === 'FORMAT CIAXLONE REPORT') continue;
 
-        const label = a.replace(/:$/, '');
+        // --- Side-column criteria (label:value in cols G/H) for the current column ---
+        if (block === 'column' && current) {
+            const g = (cols.get('G') || '').trim();
+            if (g !== '') {
+                const cf = criteriaFieldFor(g.replace(/:$/, ''));
+                if (cf) {
+                    if (cf === 'columnName') {
+                        flushCriteria();
+                        pendingCriteria = { columnName: '', action: '', field: '', details: '', display: '' };
+                    }
+                    if (pendingCriteria) pendingCriteria[cf] = (cols.get('H') || '').trim();
+                    continue;
+                }
+            }
+        }
 
         if (block === 'settings') {
-            sheet.settings[label] = b;
+            if (a === '') continue;
+            sheet.settings[a.replace(/:$/, '')] = b;
         } else if (block === 'column' && current) {
+            if (a === '') continue;
+            const label = a.replace(/:$/, '');
             if (label === 'Name') current.name = b;
             else if (label === 'Data Source') current.dataSource = parseDataSourceRef(b);
             else if (label === 'Parameters') current.parameters = parseKvString(b);
             else if (label === 'Runtime') current.runtime = parseKvString(b);
+            // 'Criteria:' label row itself carries no value; rows handled above.
+        } else if (block === 'variables') {
+            if (tableHeader == null) {
+                // First row after the section header carries the column labels.
+                tableHeader = new Map();
+                for (const [col, val] of cols) {
+                    const t = (val || '').trim();
+                    if (t !== '') tableHeader.set(col, t);
+                }
+                continue;
+            }
+            const vals = rowValues(cols);
+            // Skip an all-empty row.
+            if (vals.every((v) => v === '')) continue;
+            sheet.variables.push({
+                name: vals[0] || a,
+                description: vals[1] || '',
+                type: vals[2] || '',
+                value: vals[3] || '',
+                listValues: vals[4] || '',
+            });
+        } else if (block === 'rowcommands') {
+            if (tableHeader == null) {
+                tableHeader = new Map();
+                for (const [col, val] of cols) {
+                    const t = (val || '').trim();
+                    if (t !== '') tableHeader.set(col, t);
+                }
+                continue;
+            }
+            const vals = rowValues(cols);
+            if (vals.every((v) => v === '')) continue;
+            sheet.rowCommands.push({
+                command: vals[0] || '',
+                details: vals[1] || '',
+                selection: vals[2] || '',
+                search: vals[3] || '',
+                valueFrom: vals[4] || '',
+                valueTo: vals[5] || '',
+            });
         }
     }
-    flush();
+    flushColumn();
     return sheet;
 }
 

--- a/src/lib/parsers/types.ts
+++ b/src/lib/parsers/types.ts
@@ -98,3 +98,85 @@ export interface DashboardParsed {
     Theme?: XmlNode;
     [key: string]: XmlNode | undefined;
 }
+
+/** A resolved data-source reference parsed from a Column Definition cell. */
+export interface XlDataSourceRef {
+    /** Raw cell text, e.g. "Transactions (Financial System Administration) (GUID)". */
+    raw: string;
+    /** Leading name portion, e.g. "Transactions". */
+    name: string;
+    /** Parenthesised system portion, e.g. "Financial System Administration". */
+    system: string;
+    /** Trailing GUID, e.g. "7f09c258-8b0e-40a8-851d-9d49c0ba6215" (empty if none). */
+    guid: string;
+}
+
+/** A row in the report Variables table. */
+export interface XlVariableRow {
+    name: string;
+    description: string;
+    type: string;
+    value: string;
+    listValues: string;
+}
+
+/** A single criteria row under a column definition. */
+export interface XlCriteriaRow {
+    columnName: string;
+    action: string;
+    field: string;
+    details: string;
+    display: string;
+}
+
+/** A parsed Column Definition block from the Definition sheet. */
+export interface XlColumnDefn {
+    name: string;
+    dataSource: XlDataSourceRef | null;
+    /** Parsed `key=value;` pairs from the Parameters cell. */
+    parameters: Record<string, string>;
+    /** Parsed `key=value;` pairs from the Runtime cell. */
+    runtime: Record<string, string>;
+    criteria: XlCriteriaRow[];
+}
+
+/** A row in the Row Commands table. */
+export interface XlRowCommand {
+    command: string;
+    details: string;
+    selection: string;
+    search: string;
+    valueFrom: string;
+    valueTo: string;
+}
+
+/** The reconstructed Definition worksheet, split into structured sections. */
+export interface XlDefinitionSheet {
+    /** Report Settings as key/value (e.g. Description, Narration, Created By). */
+    settings: Record<string, string>;
+    variables: XlVariableRow[];
+    columns: XlColumnDefn[];
+    rowCommands: XlRowCommand[];
+}
+
+/** Parsed XlOne report package: thin Report.xml header/definition + xlsx sheet. */
+export interface XlReportParsed {
+    /** Fields from the MyXLOneHeader wrapper. */
+    header: {
+        reportId: string;
+        title: string;
+        description: string;
+        category: string;
+        type: string;
+        sheetName: string;
+        userId: string;
+        datasource: string;
+        reportingSystem: string;
+        parentPath: string;
+        storageType: string;
+    };
+    /** Selected fields from the nested DbReportDef (raw node kept for depth). */
+    definition: XmlNode;
+    /** Reconstructed embedded-xlsx Definition sheet. */
+    sheet: XlDefinitionSheet;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { EtlParser } from './lib/parsers/EtlParser';
 import { EtlGenerator } from './lib/generators/EtlGenerator';
 import { DataModelGenerator } from './lib/generators/DataModelGenerator';
 import { DashboardGenerator } from './lib/generators/DashboardGenerator';
+import { XlOneGenerator } from './lib/generators/XlOneGenerator';
 import { DocxGenerator } from './lib/generators/DocxGenerator';
 import { OfflineVerifier } from './lib/ux/OfflineVerifier';
 
@@ -30,7 +31,7 @@ registerServiceWorker();
 // --- Routing State ---
 let currentView: 'dashboard' | 'detail' = 'dashboard';
 let currentReportId: number | null = null;
-let currentType: 'report' | 'datamodel' | 'dashboard' = 'report';
+let currentType: 'report' | 'datamodel' | 'dashboard' | 'xlreport' = 'report';
 
 // --- HTML Template Helpers ---
 function header() {
@@ -148,6 +149,13 @@ const SECTION_DEFS = [
         accent: 'border-emerald-200',
         head: 'text-emerald-700',
     },
+    {
+        type: 'xlreport',
+        title: 'XlOne Reports',
+        dot: 'bg-amber-500',
+        accent: 'border-amber-200',
+        head: 'text-amber-700',
+    },
 ] as const;
 
 function dashboardLayout(items: any[]) {
@@ -155,6 +163,7 @@ function dashboardLayout(items: any[]) {
         report: items.filter((i) => i.type === 'report').length,
         datamodel: items.filter((i) => i.type === 'datamodel').length,
         dashboard: items.filter((i) => i.type === 'dashboard').length,
+        xlreport: items.filter((i) => i.type === 'xlreport').length,
     };
 
     const sections = SECTION_DEFS.map((s) => {
@@ -187,16 +196,17 @@ function dashboardLayout(items: any[]) {
                     </div>
                     <div class="pointer-events-none">
                         <h2 class="text-2xl font-bold leading-tight">Upload Definitions</h2>
-                        <p class="text-sm text-blue-100 mt-1">Drag & drop <code class="bg-white/20 px-1 rounded">.t1etlp</code>, <code class="bg-white/20 px-1 rounded">.t1dm</code>, <code class="bg-white/20 px-1 rounded">.t1db</code> — everything stays on your device.</p>
+                        <p class="text-sm text-blue-100 mt-1">Drag & drop <code class="bg-white/20 px-1 rounded">.t1etlp</code>, <code class="bg-white/20 px-1 rounded">.t1dm</code>, <code class="bg-white/20 px-1 rounded">.t1db</code>, <code class="bg-white/20 px-1 rounded">.t1xl</code> — everything stays on your device.</p>
                     </div>
-                    <input type="file" id="fileInput" multiple accept=".t1etlp,.t1dm,.t1db" class="hidden">
+                    <input type="file" id="fileInput" multiple accept=".t1etlp,.t1dm,.t1db,.t1xl" class="hidden">
                 </div>
                 <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5 flex flex-col justify-center">
                     <p class="text-[10px] uppercase font-bold tracking-wider text-gray-400 mb-3">Library (${items.length})</p>
-                    <div class="grid grid-cols-3 gap-2 text-center">
+                    <div class="grid grid-cols-4 gap-2 text-center">
                         <div><div class="text-2xl font-bold text-blue-600">${counts.report}</div><div class="text-[10px] text-gray-500">ETL</div></div>
                         <div><div class="text-2xl font-bold text-purple-600">${counts.datamodel}</div><div class="text-[10px] text-gray-500">Models</div></div>
                         <div><div class="text-2xl font-bold text-emerald-600">${counts.dashboard}</div><div class="text-[10px] text-gray-500">Dash</div></div>
+                        <div><div class="text-2xl font-bold text-amber-600">${counts.xlreport}</div><div class="text-[10px] text-gray-500">XlOne</div></div>
                     </div>
                 </div>
             </div>
@@ -218,10 +228,12 @@ async function render() {
         const reports = await db.reports.toArray();
         const dms = await db.dataModels.toArray();
         const dashboards = await db.dashboards.toArray();
+        const xlReports = await db.xlReports.toArray();
         const allItems = [
             ...reports.map((r) => ({ ...r, type: 'report' })),
             ...dms.map((d) => ({ ...d, type: 'datamodel' })),
             ...dashboards.map((d) => ({ ...d, type: 'dashboard' })),
+            ...xlReports.map((x) => ({ ...x, type: 'xlreport' })),
         ];
         allItems.sort((a, b) => b.dateAdded.getTime() - a.dateAdded.getTime());
         content += dashboardLayout(allItems);
@@ -236,10 +248,15 @@ async function render() {
                         Back to Library
                     </button>
 
-                    <button onclick="window.exportDocx()" class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-bold transition-all shadow-sm flex items-center justify-center">
+                    ${
+                        // XlOne reports have no .docx export in v1 — hide the button.
+                        currentType === 'xlreport'
+                            ? ''
+                            : `<button onclick="window.exportDocx()" class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-bold transition-all shadow-sm flex items-center justify-center">
                          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
                          Export
-                    </button>
+                    </button>`
+                    }
                     </div>
                  </div>
                  <div id="detailContainer" class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden w-full flex flex-col max-w-4xl mx-auto">
@@ -267,6 +284,8 @@ async function render() {
                 html = await DataModelGenerator.generateHtmlView(currentReportId);
             } else if (currentType === 'dashboard') {
                 html = await DashboardGenerator.generateHtmlView(currentReportId);
+            } else if (currentType === 'xlreport') {
+                html = await XlOneGenerator.generateHtmlView(currentReportId);
             }
             const container = document.getElementById('detailContainer');
             if (container) {
@@ -444,9 +463,13 @@ function setupDragAndDrop() {
 // --- Global Actions ---
 declare global {
     interface Window {
-        navigateTo: (view: 'dashboard' | 'detail', id?: number, type?: 'report' | 'datamodel' | 'dashboard') => void;
+        navigateTo: (
+            view: 'dashboard' | 'detail',
+            id?: number,
+            type?: 'report' | 'datamodel' | 'dashboard' | 'xlreport'
+        ) => void;
         exportDocx: () => void;
-        deleteEntity: (id: number, type: 'report' | 'datamodel' | 'dashboard') => void;
+        deleteEntity: (id: number, type: 'report' | 'datamodel' | 'dashboard' | 'xlreport') => void;
         editStepNote: (reportId: string, stepId: string) => void;
         saveStepNote: (reportId: string, stepId: string) => void;
         cancelNote: (stepId: string) => void;
@@ -485,11 +508,12 @@ window.exportJson = async () => {
         const reports = await db.reports.toArray();
         const dataModels = await db.dataModels.toArray();
         const dashboards = await db.dashboards.toArray();
+        const xlReports = await db.xlReports.toArray();
         const exportData = {
             generated: new Date().toISOString(),
             version: '1.0',
             appVersion: '3.1',
-            library: { reports, dataModels, dashboards },
+            library: { reports, dataModels, dashboards, xlReports },
         };
         const filename = `library-backup-${new Date().toISOString().slice(0, 10)}.json`;
         const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
@@ -511,12 +535,20 @@ window.verifyOffline = () => {
     new OfflineVerifier();
 };
 
-window.deleteEntity = async (id: number, type: 'report' | 'datamodel' | 'dashboard') => {
-    const typeLabel = type === 'report' ? 'Report' : type === 'datamodel' ? 'Data Model' : 'Dashboard';
+window.deleteEntity = async (id: number, type: 'report' | 'datamodel' | 'dashboard' | 'xlreport') => {
+    const typeLabel =
+        type === 'report'
+            ? 'Report'
+            : type === 'datamodel'
+              ? 'Data Model'
+              : type === 'dashboard'
+                ? 'Dashboard'
+                : 'XlOne Report';
     if (confirm(`Are you sure you want to delete this ${typeLabel}?`)) {
         if (type === 'report') await db.reports.delete(id);
         else if (type === 'datamodel') await db.dataModels.delete(id);
         else if (type === 'dashboard') await db.dashboards.delete(id);
+        else if (type === 'xlreport') await db.xlReports.delete(id);
         render();
     }
 };

--- a/tests/XlOneGenerator.test.ts
+++ b/tests/XlOneGenerator.test.ts
@@ -71,6 +71,19 @@ describe('XlOneGenerator', () => {
         expect(html).toContain('&lt;script&gt;');
     });
 
+    it('escapes meta-grid fields that start with "<" (no startsWith bypass)', async () => {
+        const content = makeParsed({
+            header: { ...makeParsed().header, userId: '<img src=x onerror=alert(3)>', type: '<b>B</b>' },
+        });
+        vi.mocked(db.xlReports.get).mockResolvedValue(
+            mockRecord(content, { name: 'r', owner: '<img src=x onerror=alert(3)>' })
+        );
+        const html = await XlOneGenerator.generateHtmlView(1);
+        expect(html).not.toContain('<img src=x onerror=alert(3)>');
+        expect(html).not.toContain('<b>B</b>');
+        expect(html).toContain('&lt;img');
+    });
+
     it('renders a column definition with its data source name', async () => {
         const content = makeParsed({
             sheet: {

--- a/tests/XlOneGenerator.test.ts
+++ b/tests/XlOneGenerator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '../src/lib/db';
+import { XlOneGenerator } from '../src/lib/generators/XlOneGenerator';
+import type { XlReportParsed } from '../src/lib/parsers/types';
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        xlReports: { get: vi.fn() },
+        dataModels: { toArray: vi.fn() },
+    },
+}));
+
+function makeParsed(overrides: Partial<XlReportParsed> = {}): XlReportParsed {
+    return {
+        header: {
+            reportId: 'rid',
+            title: 'My Report',
+            description: '',
+            category: '',
+            type: 'B',
+            sheetName: 'Definition',
+            userId: 'TESTER',
+            datasource: 'ds-guid',
+            reportingSystem: '$DEFAULT',
+            parentPath: '/Home/TESTER',
+            storageType: 'A',
+        },
+        definition: { ReportSuite: 'CES' },
+        sheet: { settings: {}, variables: [], columns: [], rowCommands: [] },
+        ...overrides,
+    };
+}
+
+function mockRecord(content: XlReportParsed, metadata: Record<string, unknown>) {
+    return { id: 1, filename: 'r.t1xl', metadata, content, dateAdded: new Date() };
+}
+
+describe('XlOneGenerator', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(db.dataModels.toArray).mockResolvedValue([]);
+    });
+
+    it('throws if the report is not found', async () => {
+        vi.mocked(db.xlReports.get).mockResolvedValue(undefined);
+        await expect(XlOneGenerator.generateHtmlView(999)).rejects.toThrow('XlOne Report not found');
+    });
+
+    it('renders the report title and owner', async () => {
+        vi.mocked(db.xlReports.get).mockResolvedValue(mockRecord(makeParsed(), { name: 'My Report', owner: 'TESTER' }));
+        const html = await XlOneGenerator.generateHtmlView(1);
+        expect(html).toContain('My Report');
+        expect(html).toContain('TESTER');
+        expect(html).toContain('XlOne Report');
+    });
+
+    it('escapes file-derived values to prevent XSS', async () => {
+        const content = makeParsed({
+            header: { ...makeParsed().header, title: '<script>alert(1)</script>' },
+            sheet: {
+                settings: { Narration: '<img src=x onerror=alert(2)>' },
+                variables: [],
+                columns: [],
+                rowCommands: [],
+            },
+        });
+        vi.mocked(db.xlReports.get).mockResolvedValue(mockRecord(content, { name: '<script>alert(1)</script>' }));
+        const html = await XlOneGenerator.generateHtmlView(1);
+        expect(html).not.toContain('<script>alert(1)</script>');
+        expect(html).not.toContain('<img src=x onerror=alert(2)>');
+        expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('renders a column definition with its data source name', async () => {
+        const content = makeParsed({
+            sheet: {
+                settings: {},
+                variables: [],
+                columns: [
+                    {
+                        name: 'ColumnDefn1',
+                        dataSource: { raw: 'Transactions (Sys) (guid)', name: 'Transactions', system: 'Sys', guid: 'guid' },
+                        parameters: {},
+                        runtime: {},
+                        criteria: [],
+                    },
+                ],
+                rowCommands: [],
+            },
+        });
+        vi.mocked(db.xlReports.get).mockResolvedValue(mockRecord(content, { name: 'r' }));
+        const html = await XlOneGenerator.generateHtmlView(1);
+        expect(html).toContain('ColumnDefn1');
+        expect(html).toContain('Transactions');
+    });
+});

--- a/tests/XlOneParser.test.ts
+++ b/tests/XlOneParser.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { XlOneParser } from '../src/lib/parsers/XlOneParser';
+
+/** Build a minimal .t1xl File with the given Report.xml and optional xlsx parts. */
+async function makeT1xl(reportXml: string, sharedStrings?: string[], sheetXml?: string): Promise<File> {
+    const outer = new JSZip();
+    outer.file('Report.xml', reportXml);
+
+    if (sharedStrings) {
+        const inner = new JSZip();
+        const si = sharedStrings.map((s) => `<si><t>${s}</t></si>`).join('');
+        inner.file(
+            'xl/sharedStrings.xml',
+            `<?xml version="1.0"?><sst count="${sharedStrings.length}" uniqueCount="${sharedStrings.length}">${si}</sst>`
+        );
+        inner.file('xl/worksheets/sheet1.xml', sheetXml || '<worksheet><sheetData/></worksheet>');
+        const innerBlob = await inner.generateAsync({ type: 'uint8array' });
+        outer.file('Report.xlsx', innerBlob);
+    }
+
+    const blob = await outer.generateAsync({ type: 'blob' });
+    return new File([blob], 'Report.t1xl');
+}
+
+const HEADER_ONLY = `<?xml version="1.0" encoding="utf-8"?>
+<MyXLOneHeader>
+  <ReportId>0725a29d-1be8-4651-893a-9ef859fa3661</ReportId>
+  <Title>Transactions</Title>
+  <Type>B</Type>
+  <UserId>BWILKINS</UserId>
+  <Datasource>7f09c258-8b0e-40a8-851d-9d49c0ba6215</Datasource>
+  <ReportingSystem>$DEFAULT</ReportingSystem>
+  <ParentFileItemPath>/Home/BWILKINS</ParentFileItemPath>
+  <ReportStorageType>A</ReportStorageType>
+  <Definition>&lt;DbReportDef&gt;&lt;ReportSuite&gt;CES&lt;/ReportSuite&gt;&lt;/DbReportDef&gt;</Definition>
+</MyXLOneHeader>`;
+
+describe('XlOneParser — header', () => {
+    it('parses MyXLOneHeader fields', async () => {
+        const file = await makeT1xl(HEADER_ONLY);
+        const result = await XlOneParser.parse(file);
+        expect(result.header.title).toBe('Transactions');
+        expect(result.header.type).toBe('B');
+        expect(result.header.datasource).toBe('7f09c258-8b0e-40a8-851d-9d49c0ba6215');
+        expect(result.header.userId).toBe('BWILKINS');
+        expect(result.header.parentPath).toBe('/Home/BWILKINS');
+    });
+
+    it('unescapes and parses the nested DbReportDef', async () => {
+        const file = await makeT1xl(HEADER_ONLY);
+        const result = await XlOneParser.parse(file);
+        expect(result.definition.ReportSuite).toBe('CES');
+    });
+
+    it('returns empty sheet sections when no xlsx present', async () => {
+        const file = await makeT1xl(HEADER_ONLY);
+        const result = await XlOneParser.parse(file);
+        expect(result.sheet.variables).toEqual([]);
+        expect(result.sheet.columns).toEqual([]);
+        expect(result.sheet.rowCommands).toEqual([]);
+        expect(result.sheet.settings).toEqual({});
+    });
+});
+
+// Cell helper: <c r="A1" t="s"><v>IDX</v></c> references sharedStrings[IDX].
+function cell(ref: string, idx: number): string {
+    return `<c r="${ref}" t="s"><v>${idx}</v></c>`;
+}
+function row(rNum: number, cells: string): string {
+    return `<row r="${rNum}">${cells}</row>`;
+}
+
+describe('XlOneParser — embedded xlsx grid', () => {
+    // Shared-string table mirroring the real Transactions sample layout.
+    const SS = [
+        'FORMAT CIAXLONE REPORT', // 0
+        'REPORT SETTINGS', // 1
+        'Description:', // 2
+        'Transactions', // 3
+        'Narration:', // 4
+        'Created By:', // 5
+        'BWILKINS - 26-Apr-2025', // 6
+        'REPORT VARIABLES', // 7
+        'COLUMN DEFINITION', // 8
+        'Name:', // 9
+        'ColumnDefn1', // 10
+        'Data Source:', // 11
+        'Transactions (Financial System Administration) (7f09c258-8b0e-40a8-851d-9d49c0ba6215)', // 12
+        'Parameters:', // 13
+        'DataSourceType=CiADataSource;ChartName=GLCHART', // 14
+        'ROW COMMANDS', // 15
+    ];
+
+    const SHEET = `<worksheet><sheetData>
+        ${row(1, cell('A1', 1))}
+        ${row(2, cell('A2', 2) + cell('B2', 3))}
+        ${row(3, cell('A3', 4))}
+        ${row(4, cell('A4', 5) + cell('B4', 6))}
+        ${row(5, cell('A5', 8))}
+        ${row(6, cell('A6', 9) + cell('B6', 10))}
+        ${row(7, cell('A7', 11) + cell('B7', 12))}
+        ${row(8, cell('A8', 13) + cell('B8', 14))}
+        ${row(9, cell('A9', 15))}
+    </sheetData></worksheet>`;
+
+    it('reconstructs settings as key/value', async () => {
+        const file = await makeT1xl(HEADER_ONLY, SS, SHEET);
+        const result = await XlOneParser.parse(file);
+        expect(result.sheet.settings['Description']).toBe('Transactions');
+        expect(result.sheet.settings['Created By']).toBe('BWILKINS - 26-Apr-2025');
+    });
+
+    it('extracts a column definition with parsed data source ref', async () => {
+        const file = await makeT1xl(HEADER_ONLY, SS, SHEET);
+        const result = await XlOneParser.parse(file);
+        expect(result.sheet.columns.length).toBe(1);
+        const col = result.sheet.columns[0];
+        expect(col.name).toBe('ColumnDefn1');
+        expect(col.dataSource?.name).toBe('Transactions');
+        expect(col.dataSource?.system).toBe('Financial System Administration');
+        expect(col.dataSource?.guid).toBe('7f09c258-8b0e-40a8-851d-9d49c0ba6215');
+    });
+
+    it('parses key=value; parameter strings', async () => {
+        const file = await makeT1xl(HEADER_ONLY, SS, SHEET);
+        const result = await XlOneParser.parse(file);
+        expect(result.sheet.columns[0].parameters['DataSourceType']).toBe('CiADataSource');
+        expect(result.sheet.columns[0].parameters['ChartName']).toBe('GLCHART');
+    });
+});

--- a/tests/XlOneParser.test.ts
+++ b/tests/XlOneParser.test.ts
@@ -129,3 +129,94 @@ describe('XlOneParser — embedded xlsx grid', () => {
         expect(result.sheet.columns[0].parameters['ChartName']).toBe('GLCHART');
     });
 });
+
+describe('XlOneParser — variables, criteria, row commands', () => {
+    // Mirrors the real Definition-sheet layout: REPORT VARIABLES is a table
+    // (header row B..F, then data rows), criteria is a side-column (G label,
+    // H value) block under a column, ROW COMMANDS is a table (header A..F).
+    const SS = [
+        'FORMAT CIAXLONE REPORT', // 0
+        'REPORT VARIABLES', // 1
+        'Variable', // 2
+        'Description', // 3
+        'Type/Edit', // 4
+        'Value', // 5
+        'List Values', // 6
+        'Period', // 7  (variable name)
+        'Period to report', // 8 (description)
+        'List', // 9 (type)
+        '2025-06', // 10 (value)
+        'P1;P2;P3', // 11 (list values)
+        'COLUMN DEFINITION', // 12
+        'Name:', // 13
+        'ColumnDefn1', // 14
+        'Criteria:', // 15
+        'Column Name:', // 16
+        'Action:', // 17
+        'Field:', // 18
+        'Details:', // 19
+        'Display:', // 20
+        'AccountCode', // 21 (criteria column name value)
+        'Equals', // 22 (action value)
+        'GL.Account', // 23 (field value)
+        '1000', // 24 (details value)
+        'Visible', // 25 (display value)
+        'ROW COMMANDS', // 26
+        'Command', // 27
+        'Details', // 28
+        'Selection', // 29
+        'Search', // 30
+        'Value (Fr)', // 31
+        'Value (To)', // 32
+        'LIST', // 33 (row command)
+        'expand', // 34
+    ];
+
+    const SHEET = `<worksheet><sheetData>
+        ${row(1, cell('A1', 0))}
+        ${row(2, cell('A2', 1))}
+        ${row(3, cell('B3', 2) + cell('C3', 3) + cell('D3', 4) + cell('E3', 5) + cell('F3', 6))}
+        ${row(4, cell('A4', 7) + cell('B4', 7) + cell('C4', 8) + cell('D4', 9) + cell('E4', 10) + cell('F4', 11))}
+        ${row(5, cell('A5', 12))}
+        ${row(6, cell('A6', 13) + cell('B6', 14))}
+        ${row(7, cell('A7', 15))}
+        ${row(8, cell('G8', 16) + cell('H8', 21))}
+        ${row(9, cell('G9', 17) + cell('H9', 22))}
+        ${row(10, cell('G10', 18) + cell('H10', 23))}
+        ${row(11, cell('G11', 19) + cell('H11', 24))}
+        ${row(12, cell('G12', 20) + cell('H12', 25))}
+        ${row(13, cell('A13', 26))}
+        ${row(14, cell('A14', 27) + cell('B14', 28) + cell('C14', 29) + cell('D14', 30) + cell('E14', 31) + cell('F14', 32))}
+        ${row(15, cell('A15', 33) + cell('B15', 34))}
+    </sheetData></worksheet>`;
+
+    it('parses the variables table', async () => {
+        const result = await XlOneParser.parse(await makeT1xl(HEADER_ONLY, SS, SHEET));
+        expect(result.sheet.variables.length).toBe(1);
+        const v = result.sheet.variables[0];
+        expect(v.name).toBe('Period');
+        expect(v.description).toBe('Period to report');
+        expect(v.type).toBe('List');
+        expect(v.value).toBe('2025-06');
+        expect(v.listValues).toBe('P1;P2;P3');
+    });
+
+    it('parses side-column criteria into the current column', async () => {
+        const result = await XlOneParser.parse(await makeT1xl(HEADER_ONLY, SS, SHEET));
+        expect(result.sheet.columns.length).toBe(1);
+        const crit = result.sheet.columns[0].criteria;
+        expect(crit.length).toBe(1);
+        expect(crit[0].columnName).toBe('AccountCode');
+        expect(crit[0].action).toBe('Equals');
+        expect(crit[0].field).toBe('GL.Account');
+        expect(crit[0].details).toBe('1000');
+        expect(crit[0].display).toBe('Visible');
+    });
+
+    it('parses the row commands table', async () => {
+        const result = await XlOneParser.parse(await makeT1xl(HEADER_ONLY, SS, SHEET));
+        expect(result.sheet.rowCommands.length).toBe(1);
+        expect(result.sheet.rowCommands[0].command).toBe('LIST');
+        expect(result.sheet.rowCommands[0].details).toBe('expand');
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new file-format module for TechnologyOne **XlOne report definitions** (`.t1xl`), mirroring the existing Dashboard pipeline (detect → parse → store → render). Closes the XlOne Reports roadmap item; also marks the already-shipped Dashboards item complete (README was stale).

A `.t1xl` is a ZIP of a thin `Report.xml` (metadata + datasource GUID + grouping/distribution config) plus an embedded `.xlsx` whose **Definition** worksheet holds the real substance. This parser reads both: structured `Report.xml` **and** a full reconstruction of the embedded xlsx Definition-sheet grid (Report Settings, Variables, Column Definitions with in-cell Data Model name/GUID, Criteria, Row Commands). No new dependency — `jszip` + `fast-xml-parser` handle both the outer and inner ZIPs.

## What changed

- **`src/lib/parsers/XlOneParser.ts`** (new) — outer unzip then `Report.xml` (unescapes nested `DbReportDef`), inner unzip the xlsx, resolve shared-string cells, reconstruct labelled-grid sections.
- **`src/lib/generators/XlOneGenerator.ts`** (new) — parsed to escaped HTML; cross-module lineage links a column's data source to a stored Data Model when the GUID matches.
- **`src/lib/parsers/types.ts`** — `XlReportParsed` plus section types (no `any` on the XML spine).
- **`src/lib/db.ts`** — Dexie `version(4)` `xlReports` store plus `XlReport` interface.
- **`src/lib/FileProcessor.ts`** — `.t1xl` branch routing to `processXlReport`.
- **`src/main.ts`** — type union, dashboard section, stats tile, upload `accept`, render dispatch, JSON export, delete, and Export-button hidden for XlOne (no docx in v1).
- **`tests/`** — fixture-driven `XlOneParser` (6) plus `XlOneGenerator` (4, incl. XSS escaping).
- **`README.md`** — roadmap reconciled with real state.
- **`docs/superpowers/specs|plans/`** — design spec plus implementation plan.

## Out of scope (v1, YAGNI)

`.docx` export (deferred); parsing live result rows (we parse the report *definition*); Playlists / Dark Mode / Mobile.

## Verification

- `tsc --noEmit` clean, `pnpm lint` 0 errors, **81/81 tests** pass, `pnpm build` clean.
- **Browser-verified** with both real samples (`Transactions`, `Balance Sheet Detail`): both parse and store under a new XlOne Reports section with amber stats tile; detail view shows title, meta grid, Report Settings, Column Definition; sparse sample renders without error; Export hidden; no raw script tags in output (XSS-safe); console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
